### PR TITLE
feat: apply industrial brutalist design to all marketing pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 
 # TypeScript
 *.tsbuildinfo
+.vercel

--- a/src/components/landing/FeatureCard.astro
+++ b/src/components/landing/FeatureCard.astro
@@ -3,13 +3,90 @@ interface Props {
   title: string;
   description: string;
   icon: string;
+  num?: string;
 }
 
-const { title, description, icon } = Astro.props;
+const { title, description, icon, num } = Astro.props;
 ---
 
-<div class="rounded-xl border border-slate-800 bg-slate-900 p-6">
-  <div class="mb-4 text-2xl" aria-hidden="true">{icon}</div>
-  <h3 class="mb-2 text-base font-semibold text-white">{title}</h3>
-  <p class="text-sm leading-relaxed text-slate-400">{description}</p>
+<div class="card">
+  {
+    num && (
+      <span class="card-num" aria-hidden="true">
+        {num}
+      </span>
+    )
+  }
+  <div class="card-icon" aria-hidden="true">{icon}</div>
+  <h3 class="card-title">{title}</h3>
+  <p class="card-desc">{description}</p>
 </div>
+
+<style>
+  .card {
+    position: relative;
+    background: var(--brutal-white);
+    border: 3px solid var(--brutal-black);
+    box-shadow: var(--brutal-shadow);
+    padding: 1.5rem;
+    transition:
+      transform 0.15s,
+      box-shadow 0.15s,
+      background 0.15s;
+    overflow: hidden;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .card {
+      transition: background 0.15s;
+    }
+  }
+
+  .card:hover {
+    background: var(--brutal-yellow);
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--brutal-black);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .card:hover {
+      transform: none;
+      box-shadow: var(--brutal-shadow);
+    }
+  }
+
+  .card-num {
+    position: absolute;
+    top: -0.5rem;
+    right: 0.75rem;
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 5rem;
+    color: var(--brutal-black);
+    opacity: 0.06;
+    line-height: 1;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .card-icon {
+    font-size: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .card-title {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 0.5rem;
+  }
+
+  .card-desc {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.8rem;
+    line-height: 1.6;
+    color: #444;
+  }
+</style>

--- a/src/components/landing/Hero.astro
+++ b/src/components/landing/Hero.astro
@@ -2,38 +2,122 @@
 
 ---
 
-<section class="px-4 py-24 text-center sm:px-6 sm:py-32">
-  <div class="mx-auto max-w-3xl">
-    <div
-      class="mb-6 inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-400"
-    >
-      <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
-      Fully offline · No server · No tracking
-    </div>
+<section class="hero">
+  <div class="hero-inner">
+    <div class="stamp-badge">v1.0 · offline · open source</div>
 
-    <h1 class="mb-6 text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
+    <h1 class="hero-heading">
       Compare files.<br />
-      <span class="text-indigo-400">Stay offline.</span>
+      Stay offline.
     </h1>
 
-    <p class="mx-auto mb-10 max-w-xl text-lg text-slate-400">
+    <p class="hero-sub">
       twish is an installable PWA for diffing configs, code, and text — side by side, in your
       browser, with no data leaving your machine.
     </p>
 
-    <div class="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+    <div class="hero-ctas">
+      <a href="/app" class="cta-primary">Open the diff tool</a>
       <a
-        href="/app"
-        class="rounded-lg bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-indigo-500"
+        href="https://github.com/abijith-suresh/twish"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="cta-secondary"
       >
-        Open the diff tool
-      </a>
-      <a
-        href="/features"
-        class="rounded-lg border border-slate-700 px-6 py-3 text-sm font-semibold text-slate-300 transition-colors hover:bg-slate-800"
-      >
-        See what it can do
+        GitHub ↗
       </a>
     </div>
   </div>
 </section>
+
+<style>
+  .hero {
+    padding: 6rem 1.5rem;
+  }
+
+  .hero-inner {
+    max-width: 48rem;
+    margin: 0 auto;
+  }
+
+  .stamp-badge {
+    display: inline-block;
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    background: var(--brutal-yellow);
+    border: 3px solid var(--brutal-black);
+    padding: 0.25rem 0.75rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .hero-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: clamp(4rem, 8vw, 7rem);
+    line-height: 0.95;
+    letter-spacing: 0.02em;
+    color: var(--brutal-black);
+    margin-bottom: 1.5rem;
+  }
+
+  .hero-sub {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 1rem;
+    line-height: 1.6;
+    color: #444;
+    max-width: 36rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .hero-ctas {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .cta-primary,
+  .cta-secondary {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    text-decoration: none;
+    padding: 0.75rem 1.5rem;
+    border: 3px solid var(--brutal-black);
+    transition:
+      transform 0.15s,
+      box-shadow 0.15s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cta-primary,
+    .cta-secondary {
+      transition: none;
+    }
+  }
+
+  .cta-primary {
+    background: var(--brutal-black);
+    color: var(--brutal-white);
+    box-shadow: var(--brutal-shadow);
+  }
+
+  .cta-primary:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--brutal-black);
+  }
+
+  .cta-secondary {
+    background: var(--brutal-white);
+    color: var(--brutal-black);
+    box-shadow: var(--brutal-shadow);
+  }
+
+  .cta-secondary:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--brutal-black);
+  }
+</style>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -2,21 +2,61 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="border-t border-slate-800 bg-slate-950">
-  <div
-    class="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 text-sm text-slate-500 sm:px-6"
-  >
-    <span>&copy; {year} twish · MIT License</span>
-    <div class="flex items-center gap-4">
-      <a href="/changelog" class="transition-colors hover:text-slate-300">Changelog</a>
+<footer class="footer">
+  <div class="footer-inner">
+    <span class="copyright">&copy; {year} twish · MIT License</span>
+    <div class="footer-links">
+      <a href="/changelog" class="footer-link">Changelog</a>
       <a
         href="https://github.com/abijith-suresh/twish"
         target="_blank"
         rel="noopener noreferrer"
-        class="transition-colors hover:text-slate-300"
+        class="footer-link"
       >
         GitHub
       </a>
     </div>
   </div>
 </footer>
+
+<style>
+  .footer {
+    border-top: 3px solid var(--brutal-black);
+    background: var(--brutal-white);
+  }
+
+  .footer-inner {
+    max-width: 80rem;
+    margin: 0 auto;
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .copyright {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--brutal-black);
+  }
+
+  .footer-links {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .footer-link {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.75rem;
+    color: var(--brutal-black);
+    text-decoration: none;
+    border-bottom: 1px solid var(--brutal-black);
+  }
+
+  .footer-link:hover {
+    border-bottom-width: 2px;
+  }
+</style>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,43 +9,29 @@ const navLinks = [
 const currentPath = Astro.url.pathname;
 ---
 
-<header class="border-b border-slate-800 bg-slate-950">
-  <div class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
-    <a href="/" class="flex items-center gap-2 text-white">
-      <span class="text-xl font-bold tracking-tight">twish</span>
-    </a>
+<header class="header">
+  <div class="header-inner">
+    <a href="/" class="logo" aria-label="twish home">twish</a>
 
-    <nav class="flex items-center gap-1">
+    <nav class="nav">
       {
         navLinks.map((link) => (
           <a
             href={link.href}
-            class:list={[
-              "rounded px-3 py-1.5 text-sm font-medium transition-colors",
-              currentPath === link.href || currentPath === link.href + "/"
-                ? "bg-slate-800 text-white"
-                : "text-slate-400 hover:bg-slate-800 hover:text-white",
-            ]}
+            class:list={`nav-link${currentPath === link.href || currentPath === link.href + "/" ? " nav-link--active" : ""}`}
           >
             {link.label}
           </a>
         ))
       }
 
-      <div class="ml-2 h-4 w-px bg-slate-700"></div>
-
-      <a
-        href="/app"
-        class="ml-2 rounded bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-500"
-      >
-        Open App
-      </a>
+      <div class="nav-divider" aria-hidden="true"></div>
 
       <a
         href="https://github.com/abijith-suresh/twish"
         target="_blank"
         rel="noopener noreferrer"
-        class="ml-1 rounded p-1.5 text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
+        class="github-link"
         aria-label="View on GitHub"
       >
         <svg
@@ -61,6 +47,121 @@ const currentPath = Astro.url.pathname;
           ></path>
         </svg>
       </a>
+
+      <a href="/app" class="open-app-btn">Open App</a>
     </nav>
   </div>
 </header>
+
+<style>
+  .header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--brutal-white);
+    border-bottom: 3px solid var(--brutal-black);
+  }
+
+  .header-inner {
+    max-width: 80rem;
+    margin: 0 auto;
+    padding: 0.625rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .logo {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 1.5rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    background: var(--brutal-yellow);
+    border: 3px solid var(--brutal-black);
+    box-shadow: var(--brutal-shadow-sm);
+    padding: 0.1rem 0.6rem;
+    text-decoration: none;
+    line-height: 1;
+  }
+
+  .nav {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .nav-link {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--brutal-black);
+    text-decoration: none;
+    padding: 0.35rem 0.6rem;
+    border-bottom: 2px solid transparent;
+    transition: border-color 0.15s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-link {
+      transition: none;
+    }
+  }
+
+  .nav-link:hover {
+    border-bottom-color: var(--brutal-black);
+  }
+
+  .nav-link--active {
+    background: var(--brutal-yellow);
+    border-bottom-color: transparent;
+  }
+
+  .nav-link--active:hover {
+    border-bottom-color: transparent;
+  }
+
+  .nav-divider {
+    width: 1px;
+    height: 1rem;
+    background: var(--brutal-black);
+    margin: 0 0.5rem;
+  }
+
+  .github-link {
+    color: var(--brutal-black);
+    padding: 0.35rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .open-app-btn {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--brutal-white);
+    background: var(--brutal-black);
+    border: 3px solid var(--brutal-black);
+    box-shadow: var(--brutal-shadow-sm);
+    padding: 0.35rem 0.75rem;
+    text-decoration: none;
+    margin-left: 0.5rem;
+    transition:
+      transform 0.15s,
+      box-shadow 0.15s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .open-app-btn {
+      transition: none;
+    }
+  }
+
+  .open-app-btn:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0 var(--brutal-black);
+  }
+</style>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -8,7 +8,11 @@ interface Props {
 const { title = "twish — diff tool" } = Astro.props;
 ---
 
-<BaseLayout title={title} description="Compare files side by side, offline, in your browser.">
+<BaseLayout
+  title={title}
+  description="Compare files side by side, offline, in your browser."
+  bodyClass="bg-slate-950 text-slate-100 antialiased"
+>
   <div class="flex h-screen flex-col overflow-hidden">
     <!-- Minimal header for the app -->
     <header

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,12 +5,14 @@ interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  bodyClass?: string;
 }
 
 const {
   title,
   description = "Offline file diff tool — compare configs and code without leaving your browser.",
   ogImage = "/og-image.png",
+  bodyClass = "",
 } = Astro.props;
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
@@ -41,8 +43,9 @@ const ogImageUrl = new URL(ogImage, Astro.site);
     <title>{title}</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalUrl} />
+    <slot name="head" />
   </head>
-  <body class="bg-slate-950 text-slate-100 antialiased">
+  <body class:list={bodyClass}>
     <slot />
   </body>
 </html>

--- a/src/layouts/MarketingLayout.astro
+++ b/src/layouts/MarketingLayout.astro
@@ -11,7 +11,12 @@ interface Props {
 const { title, description } = Astro.props;
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} bodyClass="">
+  <link
+    slot="head"
+    href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Mono:wght@400;500;700&display=swap"
+    rel="stylesheet"
+  />
   <div class="flex min-h-screen flex-col">
     <Header />
     <main class="flex-1">
@@ -20,3 +25,11 @@ const { title, description } = Astro.props;
     <Footer />
   </div>
 </BaseLayout>
+
+<style is:global>
+  body {
+    background: var(--brutal-white);
+    color: var(--brutal-black);
+    font-family: "IBM Plex Mono", monospace;
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,10 +3,10 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
 ---
 
 <MarketingLayout title="About — twish">
-  <div class="mx-auto max-w-2xl px-4 py-16 sm:px-6">
-    <h1 class="mb-8 text-3xl font-bold text-white">About twish</h1>
+  <div class="page-wrap">
+    <h1 class="page-heading">About twish</h1>
 
-    <div class="space-y-6 text-slate-300 [&_p]:leading-relaxed">
+    <div class="content">
       <p>
         twish started as a solution to a problem I kept running into at work: I manage a lot of
         config files across multiple environments, and knowing exactly what changed between versions
@@ -18,8 +18,7 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
           href="https://www.diffchecker.com"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-indigo-400 underline underline-offset-2 hover:text-indigo-300"
-          >diffchecker.com</a
+          class="inline-link">diffchecker.com</a
         > are useful, but they're online-only — which means pasting potentially sensitive config values
         into a third-party server. That felt wrong.
       </p>
@@ -34,12 +33,12 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
         contributions are welcome.
       </p>
 
-      <div class="pt-4">
+      <div class="cta-wrap">
         <a
           href="https://github.com/abijith-suresh/twish"
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition-colors hover:bg-slate-800"
+          class="github-btn"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -59,3 +58,73 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
     </div>
   </div>
 </MarketingLayout>
+
+<style>
+  .page-wrap {
+    max-width: 40rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+  }
+
+  .page-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 4rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 2rem;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    line-height: 1.7;
+    font-size: 0.9rem;
+    color: #333;
+  }
+
+  .inline-link {
+    color: var(--brutal-black);
+    border-bottom: 2px solid var(--brutal-black);
+    text-decoration: none;
+  }
+
+  .inline-link:hover {
+    background: var(--brutal-yellow);
+  }
+
+  .cta-wrap {
+    padding-top: 1rem;
+  }
+
+  .github-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    text-decoration: none;
+    padding: 0.65rem 1.25rem;
+    background: var(--brutal-black);
+    color: var(--brutal-white);
+    border: 3px solid var(--brutal-black);
+    box-shadow: var(--brutal-shadow);
+    transition:
+      transform 0.15s,
+      box-shadow 0.15s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .github-btn {
+      transition: none;
+    }
+  }
+
+  .github-btn:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--brutal-black);
+  }
+</style>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -21,21 +21,17 @@ const releases = [
 ---
 
 <MarketingLayout title="Changelog — twish">
-  <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6">
-    <h1 class="mb-8 text-3xl font-bold text-white">Changelog</h1>
+  <div class="page-wrap">
+    <h1 class="page-heading">Changelog</h1>
 
-    <div class="space-y-10">
+    <div class="releases">
       {
         releases.map((release) => (
-          <div>
-            <div class="mb-4 flex flex-wrap items-baseline gap-3">
-              <h2 class="text-xl font-bold text-white">v{release.version}</h2>
-              {release.tag && (
-                <span class="rounded-full bg-indigo-900/50 px-2.5 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-indigo-700">
-                  {release.tag}
-                </span>
-              )}
-              <time class="text-sm text-slate-500" datetime={release.date}>
+          <div class="release">
+            <div class="release-meta">
+              <h2 class="version-heading">v{release.version}</h2>
+              {release.tag && <span class="release-tag">{release.tag}</span>}
+              <time class="release-date" datetime={release.date}>
                 {new Date(release.date).toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "long",
@@ -43,10 +39,10 @@ const releases = [
                 })}
               </time>
             </div>
-            <ul class="space-y-2">
+            <ul class="change-list">
               {release.changes.map((change) => (
-                <li class="flex gap-3 text-sm text-slate-300">
-                  <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" />
+                <li class="change-item">
+                  <span class="bullet" aria-hidden="true" />
                   {change}
                 </li>
               ))}
@@ -57,3 +53,84 @@ const releases = [
     </div>
   </div>
 </MarketingLayout>
+
+<style>
+  .page-wrap {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+  }
+
+  .page-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 4rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 2rem;
+  }
+
+  .releases {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+  }
+
+  .release-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .version-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 2.5rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+  }
+
+  .release-tag {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    background: var(--brutal-yellow);
+    border: 3px solid var(--brutal-black);
+    padding: 0.15rem 0.5rem;
+  }
+
+  .release-date {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.8rem;
+    color: #666;
+  }
+
+  .change-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .change-item {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    font-size: 0.875rem;
+    color: #333;
+    line-height: 1.6;
+  }
+
+  .bullet {
+    display: inline-block;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: var(--brutal-yellow);
+    border: 1px solid var(--brutal-black);
+    flex-shrink: 0;
+    margin-top: 0.45rem;
+  }
+</style>

--- a/src/pages/docs.astro
+++ b/src/pages/docs.astro
@@ -21,101 +21,78 @@ const languages = [
 ---
 
 <MarketingLayout title="Docs — twish">
-  <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6">
-    <h1 class="mb-8 text-3xl font-bold text-white">Documentation</h1>
+  <div class="page-wrap">
+    <h1 class="page-heading">Documentation</h1>
 
     <!-- Quick start -->
-    <section class="mb-12">
-      <h2 class="mb-4 text-lg font-semibold text-white">Quick start</h2>
-      <ol class="space-y-3 text-slate-300">
-        <li class="flex gap-3">
-          <span
-            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold"
-            >1</span
-          >
+    <section class="doc-section">
+      <h2 class="section-heading">Quick start</h2>
+      <ol class="steps">
+        <li class="step">
+          <span class="step-num">1</span>
           <span>
-            Go to <a href="/app" class="text-indigo-400 hover:text-indigo-300">twish/app</a> to open the
-            diff tool.
+            Go to <a href="/app" class="inline-link">twish/app</a> to open the diff tool.
           </span>
         </li>
-        <li class="flex gap-3">
+        <li class="step">
+          <span class="step-num">2</span>
           <span
-            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold"
-            >2</span
-          >
-          <span
-            >Paste text into the <strong class="text-white">Original</strong> and <strong
-              class="text-white">Modified</strong
-            > panels — or drag and drop files onto them.</span
+            >Paste text into the <strong>Original</strong> and <strong>Modified</strong> panels — or drag
+            and drop files onto them.</span
           >
         </li>
-        <li class="flex gap-3">
-          <span
-            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold"
-            >3</span
-          >
+        <li class="step">
+          <span class="step-num">3</span>
           <span
             >Select the language for syntax highlighting using the dropdown above each panel.</span
           >
         </li>
-        <li class="flex gap-3">
+        <li class="step">
+          <span class="step-num">4</span>
           <span
-            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold"
-            >4</span
-          >
-          <span
-            >Click <strong class="text-white">Compare</strong> or press <kbd
-              class="rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-xs"
-              >Ctrl+Enter</kbd
-            > to run the diff.
+            >Click <strong>Compare</strong> or press <kbd>Ctrl+Enter</kbd> to run the diff.
           </span>
         </li>
       </ol>
     </section>
 
     <!-- Loading files -->
-    <section class="mb-12">
-      <h2 class="mb-4 text-lg font-semibold text-white">Loading files</h2>
-      <div class="space-y-3 text-sm text-slate-300">
+    <section class="doc-section">
+      <h2 class="section-heading">Loading files</h2>
+      <div class="prose">
         <p>
-          <strong class="text-white">Drag & drop</strong> — drag any text file from your file manager
-          and drop it onto either editor panel. The file content will load into that panel.
+          <strong>Drag & drop</strong> — drag any text file from your file manager and drop it onto either
+          editor panel. The file content will load into that panel.
         </p>
         <p>
-          <strong class="text-white">File picker</strong> — click the <strong class="text-white"
-            >Open File</strong
-          > button below each panel, or press <kbd
-            class="rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-xs">Ctrl+O</kbd
-          > when a panel is focused.
+          <strong>File picker</strong> — click the <strong>Open File</strong> button below each panel,
+          or press <kbd>Ctrl+O</kbd> when a panel is focused.
         </p>
         <p>
-          <strong class="text-white">Paste</strong> — click into any panel and paste text directly from
-          the clipboard.
+          <strong>Paste</strong> — click into any panel and paste text directly from the clipboard.
         </p>
       </div>
     </section>
 
     <!-- Keyboard shortcuts -->
-    <section class="mb-12">
-      <h2 class="mb-4 text-lg font-semibold text-white">Keyboard shortcuts</h2>
-      <div class="rounded-xl border border-slate-800 overflow-hidden">
-        <table class="w-full text-sm">
+    <section class="doc-section">
+      <h2 class="section-heading">Keyboard shortcuts</h2>
+      <div class="table-wrap">
+        <table class="shortcuts-table">
           <thead>
-            <tr class="border-b border-slate-800 bg-slate-900">
-              <th class="px-4 py-3 text-left font-semibold text-white">Shortcut</th>
-              <th class="px-4 py-3 text-left font-semibold text-white">Action</th>
+            <tr class="table-header-row">
+              <th class="table-th">Shortcut</th>
+              <th class="table-th">Action</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-slate-800">
+          <tbody>
             {
               shortcuts.map((s) => (
-                <tr>
-                  <td class="px-4 py-3">
-                    <kbd class="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-slate-200">
-                      {s.keys}
-                    </kbd>
+                <tr class="table-row">
+                  <td class="table-td">
+                    <kbd>{s.keys}</kbd>
                   </td>
-                  <td class="px-4 py-3 text-slate-300">{s.action}</td>
+                  <td class="table-td">{s.action}</td>
                 </tr>
               ))
             }
@@ -125,31 +102,171 @@ const languages = [
     </section>
 
     <!-- Supported languages -->
-    <section class="mb-12">
-      <h2 class="mb-4 text-lg font-semibold text-white">Supported languages</h2>
-      <div class="flex flex-wrap gap-2">
-        {
-          languages.map((lang) => (
-            <span class="rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-300">
-              {lang}
-            </span>
-          ))
-        }
+    <section class="doc-section">
+      <h2 class="section-heading">Supported languages</h2>
+      <div class="lang-list">
+        {languages.map((lang) => <span class="lang-tag">{lang}</span>)}
       </div>
     </section>
 
     <!-- Install as PWA -->
-    <section class="mb-12">
-      <h2 class="mb-4 text-lg font-semibold text-white">Install as a PWA</h2>
-      <p class="mb-3 text-sm text-slate-300">
-        twish can be installed as a desktop or mobile app, and will work completely offline after
-        installation.
-      </p>
-      <p class="text-sm text-slate-300">
-        In Chrome/Edge: click the install icon in the address bar. In Safari on iOS: tap Share → Add
-        to Home Screen. Once installed, all assets are cached and the app works without an internet
-        connection.
-      </p>
+    <section class="doc-section">
+      <h2 class="section-heading">Install as a PWA</h2>
+      <div class="prose">
+        <p>
+          twish can be installed as a desktop or mobile app, and will work completely offline after
+          installation.
+        </p>
+        <p>
+          In Chrome/Edge: click the install icon in the address bar. In Safari on iOS: tap Share →
+          Add to Home Screen. Once installed, all assets are cached and the app works without an
+          internet connection.
+        </p>
+      </div>
     </section>
   </div>
 </MarketingLayout>
+
+<style>
+  .page-wrap {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+  }
+
+  .page-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 4rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 2rem;
+  }
+
+  .doc-section {
+    margin-bottom: 3rem;
+  }
+
+  .section-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 1.75rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 1rem;
+  }
+
+  .steps {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .step {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    font-size: 0.9rem;
+    color: #333;
+    line-height: 1.6;
+  }
+
+  .step-num {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    background: var(--brutal-yellow);
+    border: 3px solid var(--brutal-black);
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .prose {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    font-size: 0.9rem;
+    color: #333;
+    line-height: 1.6;
+  }
+
+  kbd {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.8rem;
+    background: var(--brutal-white);
+    border: 3px solid var(--brutal-black);
+    padding: 0.1rem 0.4rem;
+  }
+
+  .inline-link {
+    color: var(--brutal-black);
+    border-bottom: 2px solid var(--brutal-black);
+    text-decoration: none;
+  }
+
+  .inline-link:hover {
+    background: var(--brutal-yellow);
+  }
+
+  .table-wrap {
+    border: 3px solid var(--brutal-black);
+    overflow: hidden;
+  }
+
+  .shortcuts-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+  }
+
+  .table-header-row {
+    background: var(--brutal-yellow);
+    border-bottom: 3px solid var(--brutal-black);
+  }
+
+  .table-th {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    font-family: "IBM Plex Mono", monospace;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.75rem;
+    color: var(--brutal-black);
+  }
+
+  .table-row {
+    border-bottom: 3px solid var(--brutal-black);
+  }
+
+  .table-row:last-child {
+    border-bottom: none;
+  }
+
+  .table-td {
+    padding: 0.75rem 1rem;
+    color: #333;
+  }
+
+  .lang-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .lang-tag {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 3px solid var(--brutal-black);
+    padding: 0.2rem 0.6rem;
+    background: var(--brutal-white);
+    color: var(--brutal-black);
+  }
+</style>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -95,22 +95,20 @@ const features = [
 ---
 
 <MarketingLayout title="Features — twish">
-  <div class="mx-auto max-w-4xl px-4 py-16 sm:px-6">
-    <h1 class="mb-4 text-3xl font-bold text-white">Features</h1>
-    <p class="mb-12 text-slate-400">Everything twish can do — and what's coming next.</p>
+  <div class="page-wrap">
+    <h1 class="page-heading">Features</h1>
+    <p class="page-sub">Everything twish can do — and what's coming next.</p>
 
-    <div class="space-y-12">
+    <div class="sections">
       {
         features.map((section) => (
-          <div>
-            <h2 class="mb-4 text-xs font-semibold uppercase tracking-widest text-indigo-400">
-              {section.category}
-            </h2>
-            <div class="divide-y divide-slate-800 rounded-xl border border-slate-800">
+          <div class="section">
+            <div class="category-label">{section.category}</div>
+            <div class="item-list">
               {section.items.map((item) => (
-                <div class="px-6 py-4">
-                  <h3 class="mb-1 text-sm font-semibold text-white">{item.title}</h3>
-                  <p class="text-sm text-slate-400">{item.description}</p>
+                <div class="item">
+                  <h3 class="item-title">{item.title}</h3>
+                  <p class="item-desc">{item.description}</p>
                 </div>
               ))}
             </div>
@@ -120,3 +118,73 @@ const features = [
     </div>
   </div>
 </MarketingLayout>
+
+<style>
+  .page-wrap {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+  }
+
+  .page-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 4rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 0.5rem;
+  }
+
+  .page-sub {
+    font-size: 0.9rem;
+    color: #444;
+    margin-bottom: 3rem;
+  }
+
+  .sections {
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+  }
+
+  .category-label {
+    display: inline-block;
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    background: var(--brutal-yellow);
+    border: 3px solid var(--brutal-black);
+    padding: 0.2rem 0.6rem;
+    margin-bottom: 1rem;
+  }
+
+  .item-list {
+    border: 3px solid var(--brutal-black);
+  }
+
+  .item {
+    padding: 1rem 1.25rem;
+    border-bottom: 3px solid var(--brutal-black);
+  }
+
+  .item:last-child {
+    border-bottom: none;
+  }
+
+  .item-title {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--brutal-black);
+    margin-bottom: 0.35rem;
+  }
+
+  .item-desc {
+    font-size: 0.85rem;
+    color: #444;
+    line-height: 1.6;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,35 +5,41 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
 
 const features = [
   {
+    num: "01",
     icon: "⇄",
     title: "Side-by-side diff",
     description:
       "Clean split view with line-level highlighting. See exactly what changed at a glance.",
   },
   {
+    num: "02",
     icon: "✦",
     title: "Rich code editor",
     description:
       "CodeMirror 6 with syntax highlighting for JSON, YAML, JavaScript, TypeScript, Python, Markdown, XML, and more.",
   },
   {
+    num: "03",
     icon: "↓",
     title: "Drag & drop",
     description:
       "Drop any text file onto either panel to load it instantly — no file picker dialogs needed.",
   },
   {
+    num: "04",
     icon: "⊘",
     title: "Fully offline",
     description: "Works with zero internet after the first visit. Install it as a desktop app.",
   },
   {
+    num: "05",
     icon: "⌨",
     title: "Keyboard shortcuts",
     description:
       "Ctrl+Enter to compare, Ctrl+O to open a file, Ctrl+Shift+C to clear — stay in the flow.",
   },
   {
+    num: "06",
     icon: "⚿",
     title: "Private by design",
     description:
@@ -46,13 +52,13 @@ const features = [
   <Hero />
 
   <!-- Feature grid -->
-  <section class="px-4 pb-24 sm:px-6">
-    <div class="mx-auto max-w-5xl">
-      <h2 class="mb-10 text-center text-2xl font-bold text-white">Everything you need to diff</h2>
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+  <section class="features-section">
+    <div class="features-inner">
+      <h2 class="features-heading">Everything you need to diff</h2>
+      <div class="features-grid">
         {
           features.map((f) => (
-            <FeatureCard title={f.title} description={f.description} icon={f.icon} />
+            <FeatureCard title={f.title} description={f.description} icon={f.icon} num={f.num} />
           ))
         }
       </div>
@@ -60,16 +66,102 @@ const features = [
   </section>
 
   <!-- CTA -->
-  <section class="border-t border-slate-800 px-4 py-20 text-center sm:px-6">
-    <div class="mx-auto max-w-xl">
-      <h2 class="mb-4 text-2xl font-bold text-white">Ready to compare?</h2>
-      <p class="mb-8 text-slate-400">No sign-up. No server. Just paste, drop, and diff.</p>
-      <a
-        href="/app"
-        class="rounded-lg bg-indigo-600 px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-indigo-500"
-      >
-        Open the diff tool
-      </a>
+  <section class="cta-section">
+    <div class="cta-inner">
+      <h2 class="cta-heading">Ready to compare?</h2>
+      <p class="cta-sub">No sign-up. No server. Just paste, drop, and diff.</p>
+      <a href="/app" class="cta-btn">Open the diff tool</a>
     </div>
   </section>
 </MarketingLayout>
+
+<style>
+  .features-section {
+    padding: 0 1.5rem 6rem;
+  }
+
+  .features-inner {
+    max-width: 64rem;
+    margin: 0 auto;
+  }
+
+  .features-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 2.5rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 2rem;
+  }
+
+  .features-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr;
+  }
+
+  @media (min-width: 640px) {
+    .features-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .features-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .cta-section {
+    border-top: 3px solid var(--brutal-black);
+    padding: 5rem 1.5rem;
+  }
+
+  .cta-inner {
+    max-width: 36rem;
+    margin: 0 auto;
+  }
+
+  .cta-heading {
+    font-family: "Bebas Neue", sans-serif;
+    font-size: 3rem;
+    letter-spacing: 0.05em;
+    color: var(--brutal-black);
+    margin-bottom: 0.75rem;
+  }
+
+  .cta-sub {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.9rem;
+    color: #444;
+    margin-bottom: 2rem;
+  }
+
+  .cta-btn {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    text-decoration: none;
+    padding: 0.75rem 1.75rem;
+    background: var(--brutal-black);
+    color: var(--brutal-white);
+    border: 3px solid var(--brutal-black);
+    box-shadow: var(--brutal-shadow);
+    display: inline-block;
+    transition:
+      transform 0.15s,
+      box-shadow 0.15s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cta-btn {
+      transition: none;
+    }
+  }
+
+  .cta-btn:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--brutal-black);
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+:root {
+  --brutal-black: #000000;
+  --brutal-white: #ffffff;
+  --brutal-yellow: #ffe600;
+  --brutal-shadow: 4px 4px 0 #000;
+  --brutal-shadow-sm: 2px 2px 0 #000;
+}


### PR DESCRIPTION
## Summary

- Introduces the Industrial Brutalist design system (Bebas Neue + IBM Plex Mono, electric yellow `#ffe600`, hard `4px` offset shadows, 3px black borders, zero border-radius) across all marketing pages (`/`, `/features`, `/about`, `/docs`, `/changelog`)
- Adds `bodyClass` prop and `<slot name="head">` to `BaseLayout` so `AppLayout` keeps its dark slate theme while `MarketingLayout` turns white — `/app` is completely untouched
- Removes the 5 experiment pages (`/1`–`/5`) and `ExperimentLayout.astro` that were used to prototype the design

## Linked issues

Closes #34 — `prefers-reduced-motion` guards are now applied to every transition and transform across all new components.

Related: #6 (landing page redesign), #8 (features page redesign), #9 (docs page redesign), #10 (about page redesign), #11 (changelog page redesign)

## Commits

| Commit | Scope |
|--------|-------|
| `chore` | Add `.vercel` to gitignore |
| `chore` | Add brutalist CSS custom properties to `:root` |
| `refactor` | Add `bodyClass` prop and head slot to `BaseLayout` |
| `refactor` | Preserve app dark theme via `AppLayout` `bodyClass` |
| `feat` | Configure `MarketingLayout` with brutalist fonts and body styles |
| `feat` | Rewrite `Header` and `Footer` |
| `feat` | Rewrite `Hero` |
| `feat` | Add brutalist styling and `num` prop to `FeatureCard` |
| `feat` | Apply brutalist design to all 5 marketing pages |

## Test plan

- [x] `bun run type-check` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — 6 routes generated (`/`, `/features`, `/about`, `/docs`, `/changelog`, `/app`)
- [x] Visual check: marketing pages show white background, Bebas Neue headings, IBM Plex Mono body, yellow accents
- [x] `/app` route retains dark slate theme unchanged
- [x] Nav active states highlight correctly per page
- [x] Hover lift animations work; reduced-motion preference disables transforms
- [x] Routes `/1`–`/5` return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)