### PR TITLE
feat(app): Live Split UX with changes-only toggle as default /app

### DIFF
--- a/src/components/app/DiffApp.tsx
+++ b/src/components/app/DiffApp.tsx
@@ -46,12 +46,24 @@ function buildRows(changes: Change[]): DiffRow[] {
       i += 2;
     } else if (change.removed) {
       for (const line of change.value.replace(/\n$/, "").split("\n")) {
-        rows.push({ left: line, right: null, leftLineNum: leftLine++, rightLineNum: null, type: "removed" });
+        rows.push({
+          left: line,
+          right: null,
+          leftLineNum: leftLine++,
+          rightLineNum: null,
+          type: "removed",
+        });
       }
       i++;
     } else {
       for (const line of change.value.replace(/\n$/, "").split("\n")) {
-        rows.push({ left: null, right: line, leftLineNum: null, rightLineNum: rightLine++, type: "added" });
+        rows.push({
+          left: null,
+          right: line,
+          leftLineNum: null,
+          rightLineNum: rightLine++,
+          type: "added",
+        });
       }
       i++;
     }
@@ -129,7 +141,11 @@ export default function DiffApp() {
     const changedIdx = new Set<number>();
     allRows.forEach((row, i) => {
       if (row.type !== "equal") {
-        for (let c = Math.max(0, i - CONTEXT); c <= Math.min(allRows.length - 1, i + CONTEXT); c++) {
+        for (
+          let c = Math.max(0, i - CONTEXT);
+          c <= Math.min(allRows.length - 1, i + CONTEXT);
+          c++
+        ) {
           changedIdx.add(c);
         }
       }

--- a/src/components/app/DiffApp.tsx
+++ b/src/components/app/DiffApp.tsx
@@ -1,24 +1,91 @@
-import { createSignal, onCleanup, onMount, Show } from "solid-js";
-import DiffView from "./DiffView";
+import { createEffect, createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
+import { type Change, diffLines } from "diff";
 import EditorPanel from "./EditorPanel";
-import Toolbar from "./Toolbar";
 import { type Language } from "./LanguageSelector";
 
-interface DiffState {
-  original: string;
-  modified: string;
+interface DiffRow {
+  left: string | null;
+  right: string | null;
+  leftLineNum: number | null;
+  rightLineNum: number | null;
+  type: "equal" | "added" | "removed" | "changed";
 }
+
+function buildRows(changes: Change[]): DiffRow[] {
+  const rows: DiffRow[] = [];
+  let leftLine = 1;
+  let rightLine = 1;
+  let i = 0;
+  while (i < changes.length) {
+    const change = changes[i];
+    if (!change.added && !change.removed) {
+      const lines = change.value.replace(/\n$/, "").split("\n");
+      for (const line of lines) {
+        rows.push({
+          left: line,
+          right: line,
+          leftLineNum: leftLine++,
+          rightLineNum: rightLine++,
+          type: "equal",
+        });
+      }
+      i++;
+    } else if (change.removed && i + 1 < changes.length && changes[i + 1].added) {
+      const removedLines = change.value.replace(/\n$/, "").split("\n");
+      const addedLines = changes[i + 1].value.replace(/\n$/, "").split("\n");
+      const maxLen = Math.max(removedLines.length, addedLines.length);
+      for (let j = 0; j < maxLen; j++) {
+        rows.push({
+          left: j < removedLines.length ? removedLines[j] : null,
+          right: j < addedLines.length ? addedLines[j] : null,
+          leftLineNum: j < removedLines.length ? leftLine++ : null,
+          rightLineNum: j < addedLines.length ? rightLine++ : null,
+          type: "changed",
+        });
+      }
+      i += 2;
+    } else if (change.removed) {
+      for (const line of change.value.replace(/\n$/, "").split("\n")) {
+        rows.push({ left: line, right: null, leftLineNum: leftLine++, rightLineNum: null, type: "removed" });
+      }
+      i++;
+    } else {
+      for (const line of change.value.replace(/\n$/, "").split("\n")) {
+        rows.push({ left: null, right: line, leftLineNum: null, rightLineNum: rightLine++, type: "added" });
+      }
+      i++;
+    }
+  }
+  return rows;
+}
+
+const CONTEXT = 3;
 
 export default function DiffApp() {
   const [leftContent, setLeftContent] = createSignal("");
   const [rightContent, setRightContent] = createSignal("");
   const [leftLang, setLeftLang] = createSignal<Language>("text");
   const [rightLang, setRightLang] = createSignal<Language>("text");
-  const [diffResult, setDiffResult] = createSignal<DiffState | null>(null);
+  const [diffData, setDiffData] = createSignal<{ original: string; modified: string } | null>(null);
+  const [changesOnly, setChangesOnly] = createSignal(true);
+  const [pending, setPending] = createSignal(false);
 
-  function handleCompare() {
-    setDiffResult({ original: leftContent(), modified: rightContent() });
-  }
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  createEffect(() => {
+    const _left = leftContent();
+    const _right = rightContent();
+    setPending(true);
+    if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      setDiffData({ original: _left, modified: _right });
+      setPending(false);
+    }, 400);
+  });
+
+  onCleanup(() => {
+    if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+  });
 
   function handleSwap() {
     const prevLeft = leftContent();
@@ -29,38 +96,103 @@ export default function DiffApp() {
     setRightContent(prevLeft);
     setLeftLang(prevRightLang);
     setRightLang(prevLeftLang);
-    if (diffResult()) {
-      setDiffResult({ original: prevRight, modified: prevLeft });
-    }
   }
 
   function handleClear() {
     setLeftContent("");
     setRightContent("");
-    setDiffResult(null);
+    setDiffData(null);
+    setPending(false);
   }
 
   onMount(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.ctrlKey && e.key === "Enter") {
-        e.preventDefault();
-        handleCompare();
-      }
       if (e.ctrlKey && e.shiftKey && e.key === "C") {
         e.preventDefault();
         handleClear();
       }
     }
-
     document.addEventListener("keydown", handleKeyDown);
     onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
   });
 
+  const rows = createMemo((): DiffRow[] => {
+    const d = diffData();
+    if (!d) return [];
+    const changes = diffLines(d.original, d.modified);
+    return buildRows(changes);
+  });
+
+  const filteredRows = createMemo((): DiffRow[] => {
+    if (!changesOnly()) return rows();
+    const allRows = rows();
+    const changedIdx = new Set<number>();
+    allRows.forEach((row, i) => {
+      if (row.type !== "equal") {
+        for (let c = Math.max(0, i - CONTEXT); c <= Math.min(allRows.length - 1, i + CONTEXT); c++) {
+          changedIdx.add(c);
+        }
+      }
+    });
+    return allRows.filter((_, i) => changedIdx.has(i));
+  });
+
+  const stats = createMemo(() => {
+    const all = rows();
+    const added = all.filter((r) => r.type === "added" || r.type === "changed").length;
+    const removed = all.filter((r) => r.type === "removed" || r.type === "changed").length;
+    return { added, removed };
+  });
+
+  // eslint-disable-next-line no-unassigned-vars
+  let diffPanelRef!: HTMLDivElement;
+  let changeIndices: number[] = [];
+  let currentChangeIdx = -1;
+
+  createEffect(() => {
+    const allRows = rows();
+    changeIndices = allRows.reduce<number[]>((acc, row, i) => {
+      if (row.type !== "equal") acc.push(i);
+      return acc;
+    }, []);
+    currentChangeIdx = -1;
+  });
+
+  function jumpToNextChange() {
+    if (changeIndices.length === 0) return;
+    currentChangeIdx = (currentChangeIdx + 1) % changeIndices.length;
+    const row = diffPanelRef?.querySelector(`[data-row="${changeIndices[currentChangeIdx]}"]`);
+    row?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
   return (
-    <div class="diff-app">
-      {/* Editor row */}
-      <div class="diff-editors">
-        <div class="diff-panel">
+    <div class="flex flex-col h-full overflow-hidden bg-dusk-bg">
+      {/* Toolbar */}
+      <div class="flex items-center gap-3 flex-shrink-0 px-4 py-2 bg-dusk-surface border-b border-dusk-border">
+        <span class="font-mono text-xs text-dusk-amber font-semibold tracking-widest uppercase">
+          Live diff
+        </span>
+        <span
+          class="font-mono text-xs text-dusk-subtle transition-opacity"
+          style={{ opacity: pending() ? "1" : "0" }}
+          aria-live="polite"
+        >
+          ⟳ updating…
+        </span>
+        <div class="ml-auto flex items-center gap-2">
+          <button type="button" onClick={handleSwap} class="btn-secondary text-xs">
+            Swap ⇄
+          </button>
+          <button type="button" onClick={handleClear} class="btn-secondary text-xs">
+            Clear
+          </button>
+        </div>
+      </div>
+
+      {/* 3-column content row */}
+      <div class="flex flex-1 min-h-0 overflow-hidden">
+        {/* Left editor */}
+        <div class="flex flex-1 min-w-0 flex-col border-r border-dusk-border">
           <EditorPanel
             label="Original"
             value={leftContent()}
@@ -70,7 +202,159 @@ export default function DiffApp() {
             panelId="left"
           />
         </div>
-        <div class="diff-panel diff-panel--right">
+
+        {/* Center diff panel */}
+        <div class="flex flex-col border-r border-dusk-border" style="flex: 1.2; min-width: 0;">
+          {/* Diff panel header */}
+          <div class="flex items-center gap-3 flex-shrink-0 px-3 py-2 bg-dusk-surface border-b border-dusk-border">
+            <span class="font-mono text-xs text-dusk-muted uppercase tracking-widest">Diff</span>
+            <Show when={diffData() && (stats().added > 0 || stats().removed > 0)}>
+              <span class="font-mono text-xs text-green-400">+{stats().added}</span>
+              <span class="font-mono text-xs text-red-400">-{stats().removed}</span>
+            </Show>
+            <Show when={diffData() && stats().added === 0 && stats().removed === 0}>
+              <span class="font-mono text-xs text-dusk-subtle">Identical</span>
+            </Show>
+            <div class="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={jumpToNextChange}
+                class="btn-secondary text-xs"
+                title="Jump to next change"
+              >
+                ↓ Next
+              </button>
+              {/* Changes only toggle */}
+              <label class="flex items-center gap-1.5 cursor-pointer select-none">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={changesOnly()}
+                  onClick={() => setChangesOnly((v) => !v)}
+                  class={[
+                    "relative inline-flex w-8 h-4 border transition-colors",
+                    changesOnly()
+                      ? "bg-dusk-amber border-dusk-amber"
+                      : "bg-dusk-bg border-dusk-border",
+                  ].join(" ")}
+                >
+                  <span
+                    class={[
+                      "absolute top-0.5 w-3 h-3 bg-dusk-bg transition-transform",
+                      changesOnly() ? "translate-x-3.5" : "translate-x-0.5",
+                    ].join(" ")}
+                  />
+                </button>
+                <span class="font-mono text-xs text-dusk-muted">Changes only</span>
+              </label>
+            </div>
+          </div>
+
+          {/* Diff table */}
+          <div ref={diffPanelRef} class="flex-1 min-h-0 overflow-auto font-mono text-xs">
+            <Show
+              when={diffData()}
+              fallback={
+                <div class="flex items-center justify-center h-full font-mono text-xs text-dusk-subtle">
+                  Start typing to compare.
+                </div>
+              }
+            >
+              <Show
+                when={filteredRows().length > 0}
+                fallback={
+                  <div class="flex items-center justify-center h-full font-mono text-xs text-dusk-subtle">
+                    No differences found.
+                  </div>
+                }
+              >
+                <table class="diff-table">
+                  <colgroup>
+                    <col class="col-linenum" />
+                    <col class="col-content" />
+                    <col class="col-linenum" />
+                    <col class="col-content" />
+                  </colgroup>
+                  <tbody>
+                    {filteredRows().map((row, i) => {
+                      const isRemoved = row.type === "removed" || row.type === "changed";
+                      const isAdded = row.type === "added" || row.type === "changed";
+                      return (
+                        <tr class="diff-row" data-row={i}>
+                          <td
+                            class={[
+                              "diff-linenum",
+                              isRemoved && row.left !== null ? "diff-linenum--removed" : "",
+                              row.left === null ? "diff-cell--empty" : "",
+                            ]
+                              .join(" ")
+                              .trim()}
+                          >
+                            {row.leftLineNum}
+                          </td>
+                          <td
+                            class={[
+                              "diff-content",
+                              isRemoved && row.left !== null ? "diff-content--removed" : "",
+                              row.left === null ? "diff-cell--empty" : "",
+                            ]
+                              .join(" ")
+                              .trim()}
+                          >
+                            {row.left !== null && (
+                              <>
+                                {isRemoved && (
+                                  <span class="diff-marker diff-marker--removed" aria-hidden="true">
+                                    -
+                                  </span>
+                                )}
+                                {row.left}
+                              </>
+                            )}
+                          </td>
+                          <td
+                            class={[
+                              "diff-linenum",
+                              isAdded && row.right !== null ? "diff-linenum--added" : "",
+                              row.right === null ? "diff-cell--empty" : "",
+                            ]
+                              .join(" ")
+                              .trim()}
+                          >
+                            {row.rightLineNum}
+                          </td>
+                          <td
+                            class={[
+                              "diff-content",
+                              isAdded && row.right !== null ? "diff-content--added" : "",
+                              row.right === null ? "diff-cell--empty" : "",
+                            ]
+                              .join(" ")
+                              .trim()}
+                          >
+                            {row.right !== null && (
+                              <>
+                                {isAdded && (
+                                  <span class="diff-marker diff-marker--added" aria-hidden="true">
+                                    +
+                                  </span>
+                                )}
+                                {row.right}
+                              </>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </Show>
+            </Show>
+          </div>
+        </div>
+
+        {/* Right editor */}
+        <div class="flex flex-1 min-w-0 flex-col">
           <EditorPanel
             label="Modified"
             value={rightContent()}
@@ -81,24 +365,6 @@ export default function DiffApp() {
           />
         </div>
       </div>
-
-      {/* Toolbar */}
-      <Toolbar onCompare={handleCompare} onSwap={handleSwap} onClear={handleClear} />
-
-      {/* Diff output */}
-      <Show when={diffResult()}>
-        {(result) => (
-          <div class="diff-output">
-            <DiffView original={result().original} modified={result().modified} />
-          </div>
-        )}
-      </Show>
-
-      <Show when={!diffResult()}>
-        <div class="diff-hint">
-          Paste or drop content above, then click Compare or press Ctrl+Enter.
-        </div>
-      </Show>
     </div>
   );
 }

--- a/src/components/landing/FeatureCard.astro
+++ b/src/components/landing/FeatureCard.astro
@@ -9,84 +9,26 @@ interface Props {
 const { title, description, icon, num } = Astro.props;
 ---
 
-<div class="card">
+<div
+  class="relative bg-dusk-surface border border-dusk-border hover:border-dusk-amber transition-colors p-6 overflow-hidden"
+>
   {
     num && (
-      <span class="card-num" aria-hidden="true">
+      <span
+        class="absolute top-0 right-3 font-mono text-[5rem] text-dusk-text/5 leading-none pointer-events-none select-none"
+        aria-hidden="true"
+      >
         {num}
       </span>
     )
   }
-  <div class="card-icon" aria-hidden="true">{icon}</div>
-  <h3 class="card-title">{title}</h3>
-  <p class="card-desc">{description}</p>
+  <div class="text-2xl mb-3" aria-hidden="true">{icon}</div>
+  <h3
+    class="font-[Manrope,sans-serif] font-bold text-sm text-dusk-text uppercase tracking-wide mb-2"
+  >
+    {title}
+  </h3>
+  <p class="font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed">
+    {description}
+  </p>
 </div>
-
-<style>
-  .card {
-    position: relative;
-    background: var(--brutal-white);
-    border: 3px solid var(--brutal-black);
-    box-shadow: var(--brutal-shadow);
-    padding: 1.5rem;
-    transition:
-      transform 0.15s,
-      box-shadow 0.15s,
-      background 0.15s;
-    overflow: hidden;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .card {
-      transition: background 0.15s;
-    }
-  }
-
-  .card:hover {
-    background: var(--brutal-yellow);
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--brutal-black);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .card:hover {
-      transform: none;
-      box-shadow: var(--brutal-shadow);
-    }
-  }
-
-  .card-num {
-    position: absolute;
-    top: -0.5rem;
-    right: 0.75rem;
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 5rem;
-    color: var(--brutal-black);
-    opacity: 0.06;
-    line-height: 1;
-    pointer-events: none;
-    user-select: none;
-  }
-
-  .card-icon {
-    font-size: 1.5rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .card-title {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.9rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 0.5rem;
-  }
-
-  .card-desc {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.8rem;
-    line-height: 1.6;
-    color: #444;
-  }
-</style>

--- a/src/components/landing/Hero.astro
+++ b/src/components/landing/Hero.astro
@@ -2,122 +2,39 @@
 
 ---
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="stamp-badge">v1.0 · offline · open source</div>
+<section class="px-6 py-24">
+  <div class="max-w-2xl mx-auto">
+    <p class="font-mono text-xs text-dusk-amber uppercase tracking-widest mb-6">
+      v1.0 &middot; offline &middot; open source
+    </p>
 
-    <h1 class="hero-heading">
+    <h1
+      class="font-[Manrope,sans-serif] font-extrabold text-[clamp(3rem,7vw,5.5rem)] leading-[0.95] mb-6"
+    >
       Compare files.<br />
-      Stay offline.
+      <span class="text-dusk-muted">Stay offline.</span>
     </h1>
 
-    <p class="hero-sub">
+    <p class="font-[Manrope,sans-serif] text-base text-dusk-muted leading-relaxed max-w-lg mb-10">
       twish is an installable PWA for diffing configs, code, and text — side by side, in your
       browser, with no data leaving your machine.
     </p>
 
-    <div class="hero-ctas">
-      <a href="/app" class="cta-primary">Open the diff tool</a>
+    <div class="flex flex-wrap gap-4">
+      <a
+        href="/app"
+        class="font-[Manrope,sans-serif] text-sm font-semibold text-dusk-amber border border-dusk-amber hover:bg-dusk-amber hover:text-dusk-bg transition-colors px-6 py-3 no-underline"
+      >
+        Open the diff tool
+      </a>
       <a
         href="https://github.com/abijith-suresh/twish"
         target="_blank"
         rel="noopener noreferrer"
-        class="cta-secondary"
+        class="font-[Manrope,sans-serif] text-sm font-medium text-dusk-muted hover:text-dusk-text transition-colors px-6 py-3 no-underline"
       >
         GitHub ↗
       </a>
     </div>
   </div>
 </section>
-
-<style>
-  .hero {
-    padding: 6rem 1.5rem;
-  }
-
-  .hero-inner {
-    max-width: 48rem;
-    margin: 0 auto;
-  }
-
-  .stamp-badge {
-    display: inline-block;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    background: var(--brutal-yellow);
-    border: 3px solid var(--brutal-black);
-    padding: 0.25rem 0.75rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .hero-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: clamp(4rem, 8vw, 7rem);
-    line-height: 0.95;
-    letter-spacing: 0.02em;
-    color: var(--brutal-black);
-    margin-bottom: 1.5rem;
-  }
-
-  .hero-sub {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 1rem;
-    line-height: 1.6;
-    color: #444;
-    max-width: 36rem;
-    margin-bottom: 2.5rem;
-  }
-
-  .hero-ctas {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-  }
-
-  .cta-primary,
-  .cta-secondary {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.9rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    text-decoration: none;
-    padding: 0.75rem 1.5rem;
-    border: 3px solid var(--brutal-black);
-    transition:
-      transform 0.15s,
-      box-shadow 0.15s;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .cta-primary,
-    .cta-secondary {
-      transition: none;
-    }
-  }
-
-  .cta-primary {
-    background: var(--brutal-black);
-    color: var(--brutal-white);
-    box-shadow: var(--brutal-shadow);
-  }
-
-  .cta-primary:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--brutal-black);
-  }
-
-  .cta-secondary {
-    background: var(--brutal-white);
-    color: var(--brutal-black);
-    box-shadow: var(--brutal-shadow);
-  }
-
-  .cta-secondary:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--brutal-black);
-  }
-</style>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -2,61 +2,26 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="footer">
-  <div class="footer-inner">
-    <span class="copyright">&copy; {year} twish · MIT License</span>
-    <div class="footer-links">
-      <a href="/changelog" class="footer-link">Changelog</a>
+<footer class="border-t border-dusk-border">
+  <div class="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+    <span class="font-mono text-xs text-dusk-subtle uppercase tracking-widest">
+      &copy; {year} twish &middot; MIT License
+    </span>
+    <div class="flex items-center gap-6">
+      <a
+        href="/changelog"
+        class="font-mono text-xs text-dusk-subtle hover:text-dusk-muted no-underline transition-colors"
+      >
+        Changelog
+      </a>
       <a
         href="https://github.com/abijith-suresh/twish"
         target="_blank"
         rel="noopener noreferrer"
-        class="footer-link"
+        class="font-mono text-xs text-dusk-subtle hover:text-dusk-muted no-underline transition-colors"
       >
         GitHub
       </a>
     </div>
   </div>
 </footer>
-
-<style>
-  .footer {
-    border-top: 3px solid var(--brutal-black);
-    background: var(--brutal-white);
-  }
-
-  .footer-inner {
-    max-width: 80rem;
-    margin: 0 auto;
-    padding: 1rem 1.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .copyright {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--brutal-black);
-  }
-
-  .footer-links {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-  }
-
-  .footer-link {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    color: var(--brutal-black);
-    text-decoration: none;
-    border-bottom: 1px solid var(--brutal-black);
-  }
-
-  .footer-link:hover {
-    border-bottom-width: 2px;
-  }
-</style>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,29 +9,40 @@ const navLinks = [
 const currentPath = Astro.url.pathname;
 ---
 
-<header class="header">
-  <div class="header-inner">
-    <a href="/" class="logo" aria-label="twish home">twish</a>
+<header class="sticky top-0 z-100 bg-dusk-bg border-b border-dusk-border">
+  <div class="max-w-7xl mx-auto px-6 py-2.5 flex items-center justify-between">
+    <a
+      href="/"
+      class="font-[Manrope,sans-serif] font-bold text-xl text-dusk-text tracking-tight no-underline"
+      aria-label="twish home"
+    >
+      twish
+    </a>
 
-    <nav class="nav">
+    <nav class="flex items-center gap-1">
       {
         navLinks.map((link) => (
           <a
             href={link.href}
-            class:list={`nav-link${currentPath === link.href || currentPath === link.href + "/" ? " nav-link--active" : ""}`}
+            class:list={[
+              "font-[Manrope,sans-serif] text-sm no-underline px-3 py-1.5 transition-colors",
+              currentPath === link.href || currentPath === link.href + "/"
+                ? "text-dusk-text"
+                : "text-dusk-muted hover:text-dusk-text",
+            ]}
           >
             {link.label}
           </a>
         ))
       }
 
-      <div class="nav-divider" aria-hidden="true"></div>
+      <div class="w-px h-4 bg-dusk-border mx-2" aria-hidden="true"></div>
 
       <a
         href="https://github.com/abijith-suresh/twish"
         target="_blank"
         rel="noopener noreferrer"
-        class="github-link"
+        class="text-dusk-muted hover:text-dusk-text transition-colors p-1.5 flex items-center"
         aria-label="View on GitHub"
       >
         <svg
@@ -48,120 +59,12 @@ const currentPath = Astro.url.pathname;
         </svg>
       </a>
 
-      <a href="/app" class="open-app-btn">Open App</a>
+      <a
+        href="/app"
+        class="ml-2 font-[Manrope,sans-serif] text-sm font-semibold text-dusk-amber border border-dusk-amber hover:bg-dusk-amber hover:text-dusk-bg transition-colors px-3 py-1.5 no-underline"
+      >
+        Open App
+      </a>
     </nav>
   </div>
 </header>
-
-<style>
-  .header {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: var(--brutal-white);
-    border-bottom: 3px solid var(--brutal-black);
-  }
-
-  .header-inner {
-    max-width: 80rem;
-    margin: 0 auto;
-    padding: 0.625rem 1.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .logo {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 1.5rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    background: var(--brutal-yellow);
-    border: 3px solid var(--brutal-black);
-    box-shadow: var(--brutal-shadow-sm);
-    padding: 0.1rem 0.6rem;
-    text-decoration: none;
-    line-height: 1;
-  }
-
-  .nav {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-  }
-
-  .nav-link {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.8rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--brutal-black);
-    text-decoration: none;
-    padding: 0.35rem 0.6rem;
-    border-bottom: 2px solid transparent;
-    transition: border-color 0.15s;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .nav-link {
-      transition: none;
-    }
-  }
-
-  .nav-link:hover {
-    border-bottom-color: var(--brutal-black);
-  }
-
-  .nav-link--active {
-    background: var(--brutal-yellow);
-    border-bottom-color: transparent;
-  }
-
-  .nav-link--active:hover {
-    border-bottom-color: transparent;
-  }
-
-  .nav-divider {
-    width: 1px;
-    height: 1rem;
-    background: var(--brutal-black);
-    margin: 0 0.5rem;
-  }
-
-  .github-link {
-    color: var(--brutal-black);
-    padding: 0.35rem;
-    display: flex;
-    align-items: center;
-  }
-
-  .open-app-btn {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.8rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--brutal-white);
-    background: var(--brutal-black);
-    border: 3px solid var(--brutal-black);
-    box-shadow: var(--brutal-shadow-sm);
-    padding: 0.35rem 0.75rem;
-    text-decoration: none;
-    margin-left: 0.5rem;
-    transition:
-      transform 0.15s,
-      box-shadow 0.15s;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .open-app-btn {
-      transition: none;
-    }
-  }
-
-  .open-app-btn:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 4px 4px 0 var(--brutal-black);
-  }
-</style>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -11,32 +11,50 @@ const { title = "twish — diff tool" } = Astro.props;
 <BaseLayout
   title={title}
   description="Compare files side by side, offline, in your browser."
-  bodyClass="bg-white text-black antialiased"
+  bodyClass="bg-dusk-bg text-dusk-text antialiased"
 >
   <link
     slot="head"
-    href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Mono:wght@400;500;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet"
   />
-  <div class="app-shell">
-    <!-- Brutal header -->
-    <header class="app-header">
-      <a href="/" class="app-logo" aria-label="twish home">twish</a>
-      <nav class="app-nav">
-        <a href="/docs" class="app-nav-link">Docs</a>
-        <a href="/features" class="app-nav-link">Features</a>
-        <div class="app-nav-divider" aria-hidden="true"></div>
+  <div class="flex flex-col h-screen overflow-hidden font-[Manrope,sans-serif]">
+    <!-- App header -->
+    <header
+      class="flex items-center justify-between flex-shrink-0 px-5 py-2 bg-dusk-bg border-b border-dusk-border"
+    >
+      <a
+        href="/"
+        class="font-[Manrope,sans-serif] font-bold text-lg text-dusk-text tracking-tight no-underline"
+        aria-label="twish home"
+      >
+        twish
+      </a>
+      <nav class="flex items-center gap-1">
+        <a
+          href="/docs"
+          class="font-[Manrope,sans-serif] text-sm text-dusk-muted hover:text-dusk-text transition-colors px-3 py-1.5 no-underline"
+        >
+          Docs
+        </a>
+        <a
+          href="/features"
+          class="font-[Manrope,sans-serif] text-sm text-dusk-muted hover:text-dusk-text transition-colors px-3 py-1.5 no-underline"
+        >
+          Features
+        </a>
+        <div class="w-px h-4 bg-dusk-border mx-2" aria-hidden="true"></div>
         <a
           href="https://github.com/abijith-suresh/twish"
           target="_blank"
           rel="noopener noreferrer"
-          class="app-github-link"
+          class="text-dusk-muted hover:text-dusk-text transition-colors p-1.5 flex items-center"
           aria-label="View on GitHub"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
+            width="16"
+            height="16"
             viewBox="0 0 24 24"
             fill="currentColor"
             aria-hidden="true"
@@ -50,449 +68,8 @@ const { title = "twish — diff tool" } = Astro.props;
     </header>
 
     <!-- App content fills the rest of the screen -->
-    <div class="app-content">
+    <div class="flex-1 min-h-0 overflow-hidden">
       <slot />
     </div>
   </div>
 </BaseLayout>
-
-<style>
-  .app-shell {
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-    overflow: hidden;
-    font-family: "IBM Plex Mono", monospace;
-    background: #ffffff;
-    color: #000000;
-  }
-
-  .app-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.5rem 1.25rem;
-    background: #ffffff;
-    border-bottom: 3px solid #000000;
-    flex-shrink: 0;
-  }
-
-  .app-logo {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 1.5rem;
-    letter-spacing: 0.05em;
-    color: #000000;
-    background: #ffe600;
-    border: 3px solid #000000;
-    box-shadow: 2px 2px 0 #000000;
-    padding: 0.1rem 0.6rem;
-    text-decoration: none;
-    line-height: 1;
-  }
-
-  .app-nav {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-  }
-
-  .app-nav-link {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #000000;
-    text-decoration: none;
-    padding: 0.35rem 0.6rem;
-    border-bottom: 2px solid transparent;
-    transition: border-color 0.15s;
-  }
-
-  .app-nav-link:hover {
-    border-bottom-color: #000000;
-  }
-
-  .app-nav-divider {
-    width: 1px;
-    height: 1rem;
-    background: #000000;
-    margin: 0 0.5rem;
-  }
-
-  .app-github-link {
-    color: #000000;
-    padding: 0.35rem;
-    display: flex;
-    align-items: center;
-  }
-
-  .app-content {
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-  }
-</style>
-
-<style is:global>
-  /* ─── App shell ─────────────────────────────────────── */
-  .diff-app {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: hidden;
-    font-family: "IBM Plex Mono", monospace;
-  }
-
-  /* ─── Editor row ─────────────────────────────────────── */
-  .diff-editors {
-    display: flex;
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-  }
-
-  .diff-panel {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .diff-panel--right {
-    border-left: 3px solid #000000;
-  }
-
-  /* ─── Toolbar ─────────────────────────────────────────── */
-  .toolbar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-shrink: 0;
-    padding: 0.5rem 1rem;
-    background: #ffffff;
-    border-bottom: 3px solid #000000;
-  }
-
-  .btn-compare {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: #ffe600;
-    color: #000000;
-    border: 3px solid #000000;
-    box-shadow: 2px 2px 0 #000000;
-    padding: 0.35rem 0.75rem;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    cursor: pointer;
-    transition:
-      transform 0.12s,
-      box-shadow 0.12s;
-  }
-
-  .btn-compare:hover {
-    transform: translate(-1px, -1px);
-    box-shadow: 4px 4px 0 #000000;
-  }
-
-  .btn-secondary {
-    background: #ffffff;
-    color: #000000;
-    border: 3px solid #000000;
-    box-shadow: 2px 2px 0 #000000;
-    padding: 0.35rem 0.75rem;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    cursor: pointer;
-    transition:
-      transform 0.12s,
-      box-shadow 0.12s;
-  }
-
-  .btn-secondary:hover {
-    transform: translate(-1px, -1px);
-    box-shadow: 4px 4px 0 #000000;
-  }
-
-  .kbd {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.65rem;
-    font-weight: 400;
-    background: #000000;
-    color: #ffe600;
-    border: 1px solid #000000;
-    padding: 0.1rem 0.35rem;
-  }
-
-  /* ─── Editor panel ────────────────────────────────────── */
-  .editor-panel {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-    border: 3px solid #000000;
-    box-shadow: 4px 4px 0 #000000;
-    margin: 6px;
-    overflow: hidden;
-  }
-
-  .editor-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-shrink: 0;
-    padding: 0.375rem 0.75rem;
-    background: #ffffff;
-    border-bottom: 3px solid #000000;
-  }
-
-  .editor-label {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #000000;
-  }
-
-  .lang-select {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-    background: #ffffff;
-    color: #000000;
-    border: 2px solid #000000;
-    padding: 0.2rem 0.4rem;
-    cursor: pointer;
-    outline: none;
-  }
-
-  .lang-select:focus {
-    box-shadow: 2px 2px 0 #000000;
-  }
-
-  .editor-drop-zone {
-    position: relative;
-    flex: 1;
-    min-height: 0;
-  }
-
-  .editor-drop-overlay {
-    position: absolute;
-    inset: 0;
-    z-index: 10;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(255, 230, 0, 0.85);
-    border: 3px dashed #000000;
-    pointer-events: none;
-  }
-
-  .editor-drop-label {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.85rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #000000;
-  }
-
-  .editor-cm-host {
-    height: 100%;
-  }
-
-  .editor-cm-host .cm-editor {
-    height: 100%;
-  }
-
-  .editor-cm-host .cm-scroller {
-    overflow: auto;
-  }
-
-  .editor-footer {
-    flex-shrink: 0;
-    padding: 0.375rem 0.75rem;
-    background: #ffffff;
-    border-top: 2px solid #000000;
-  }
-
-  .editor-open-btn {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-    color: #555555;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    text-decoration: underline;
-    text-underline-offset: 2px;
-  }
-
-  .editor-open-btn:hover {
-    color: #000000;
-  }
-
-  /* ─── Diff output ─────────────────────────────────────── */
-  .diff-output {
-    flex: 1;
-    min-height: 0;
-    overflow: auto;
-    border-top: 3px solid #000000;
-  }
-
-  .diff-hint {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1.25rem;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-    color: #888888;
-  }
-
-  /* ─── DiffView ────────────────────────────────────────── */
-  .diff-empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 3rem;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.8rem;
-    color: #555555;
-  }
-
-  .diff-wrap {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
-  .diff-stats {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex-shrink: 0;
-    padding: 0.4rem 1rem;
-    background: #ffffff;
-    border-bottom: 3px solid #000000;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-  }
-
-  .diff-stats-label {
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    color: #000000;
-  }
-
-  .diff-added {
-    color: #166534;
-    font-weight: 700;
-  }
-
-  .diff-removed {
-    color: #991b1b;
-    font-weight: 700;
-  }
-
-  .diff-identical {
-    color: #555555;
-  }
-
-  .diff-table-wrap {
-    flex: 1;
-    overflow: auto;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-  }
-
-  .diff-table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  .col-linenum {
-    width: 2.5rem;
-  }
-
-  .col-content {
-    width: calc(50% - 2.5rem);
-  }
-
-  .diff-row {
-    border-bottom: 1px solid #e5e5e5;
-  }
-
-  .diff-linenum {
-    user-select: none;
-    padding: 0.15rem 0.5rem;
-    text-align: right;
-    color: #aaaaaa;
-    background: #f8f8f8;
-    white-space: nowrap;
-  }
-
-  .diff-linenum--removed {
-    background: #fee2e2;
-    color: #991b1b;
-  }
-
-  .diff-linenum--added {
-    background: #dcfce7;
-    color: #166534;
-  }
-
-  .diff-content {
-    padding: 0.15rem 0.75rem;
-    white-space: pre;
-    color: #111111;
-  }
-
-  .diff-content--removed {
-    background: #fee2e2;
-    color: #7f1d1d;
-  }
-
-  .diff-content--added {
-    background: #dcfce7;
-    color: #14532d;
-  }
-
-  .diff-cell--empty {
-    background: #f3f3f3;
-  }
-
-  .diff-marker {
-    margin-right: 0.4rem;
-    font-weight: 700;
-  }
-
-  .diff-marker--removed {
-    color: #dc2626;
-  }
-
-  .diff-marker--added {
-    color: #16a34a;
-  }
-
-  /* ─── Utility ─────────────────────────────────────────── */
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-  }
-</style>

--- a/src/layouts/MarketingLayout.astro
+++ b/src/layouts/MarketingLayout.astro
@@ -11,13 +11,17 @@ interface Props {
 const { title, description } = Astro.props;
 ---
 
-<BaseLayout title={title} description={description} bodyClass="">
+<BaseLayout
+  title={title}
+  description={description}
+  bodyClass="bg-dusk-bg text-dusk-text antialiased"
+>
   <link
     slot="head"
-    href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Mono:wght@400;500;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
     rel="stylesheet"
   />
-  <div class="flex min-h-screen flex-col">
+  <div class="flex min-h-screen flex-col font-[Manrope,sans-serif]">
     <Header />
     <main class="flex-1">
       <slot />
@@ -25,11 +29,3 @@ const { title, description } = Astro.props;
     <Footer />
   </div>
 </BaseLayout>
-
-<style is:global>
-  body {
-    background: var(--brutal-white);
-    color: var(--brutal-black);
-    font-family: "IBM Plex Mono", monospace;
-  }
-</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,10 +3,15 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
 ---
 
 <MarketingLayout title="About — twish">
-  <div class="page-wrap">
-    <h1 class="page-heading">About twish</h1>
+  <div class="max-w-2xl mx-auto px-6 py-16">
+    <p class="font-mono text-xs text-dusk-amber uppercase tracking-widest mb-4">About</p>
+    <h1 class="font-[Manrope,sans-serif] font-extrabold text-4xl text-dusk-text mb-10">
+      About twish
+    </h1>
 
-    <div class="content">
+    <div
+      class="flex flex-col gap-5 font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed"
+    >
       <p>
         twish started as a solution to a problem I kept running into at work: I manage a lot of
         config files across multiple environments, and knowing exactly what changed between versions
@@ -14,12 +19,16 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
       </p>
 
       <p>
-        Tools like <a
+        Tools like{" "}
+        <a
           href="https://www.diffchecker.com"
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-link">diffchecker.com</a
-        > are useful, but they're online-only — which means pasting potentially sensitive config values
+          class="text-dusk-text underline underline-offset-2 decoration-dusk-border hover:decoration-dusk-amber transition-colors"
+        >
+          diffchecker.com
+        </a>{" "}
+        are useful, but they're online-only — which means pasting potentially sensitive config values
         into a third-party server. That felt wrong.
       </p>
 
@@ -33,12 +42,12 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
         contributions are welcome.
       </p>
 
-      <div class="cta-wrap">
+      <div class="pt-4">
         <a
           href="https://github.com/abijith-suresh/twish"
           target="_blank"
           rel="noopener noreferrer"
-          class="github-btn"
+          class="inline-flex items-center gap-2 font-semibold text-sm text-dusk-amber border border-dusk-amber hover:bg-dusk-amber hover:text-dusk-bg transition-colors px-5 py-2.5 no-underline"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -58,73 +67,3 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
     </div>
   </div>
 </MarketingLayout>
-
-<style>
-  .page-wrap {
-    max-width: 40rem;
-    margin: 0 auto;
-    padding: 4rem 1.5rem;
-  }
-
-  .page-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 4rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 2rem;
-  }
-
-  .content {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    line-height: 1.7;
-    font-size: 0.9rem;
-    color: #333;
-  }
-
-  .inline-link {
-    color: var(--brutal-black);
-    border-bottom: 2px solid var(--brutal-black);
-    text-decoration: none;
-  }
-
-  .inline-link:hover {
-    background: var(--brutal-yellow);
-  }
-
-  .cta-wrap {
-    padding-top: 1rem;
-  }
-
-  .github-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.85rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    text-decoration: none;
-    padding: 0.65rem 1.25rem;
-    background: var(--brutal-black);
-    color: var(--brutal-white);
-    border: 3px solid var(--brutal-black);
-    box-shadow: var(--brutal-shadow);
-    transition:
-      transform 0.15s,
-      box-shadow 0.15s;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .github-btn {
-      transition: none;
-    }
-  }
-
-  .github-btn:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--brutal-black);
-  }
-</style>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -21,17 +21,26 @@ const releases = [
 ---
 
 <MarketingLayout title="Changelog — twish">
-  <div class="page-wrap">
-    <h1 class="page-heading">Changelog</h1>
+  <div class="max-w-2xl mx-auto px-6 py-16">
+    <p class="font-mono text-xs text-dusk-amber uppercase tracking-widest mb-4">Changelog</p>
+    <h1 class="font-[Manrope,sans-serif] font-extrabold text-4xl text-dusk-text mb-12">
+      Changelog
+    </h1>
 
-    <div class="releases">
+    <div class="flex flex-col gap-10">
       {
         releases.map((release) => (
-          <div class="release">
-            <div class="release-meta">
-              <h2 class="version-heading">v{release.version}</h2>
-              {release.tag && <span class="release-tag">{release.tag}</span>}
-              <time class="release-date" datetime={release.date}>
+          <div>
+            <div class="flex flex-wrap items-baseline gap-3 mb-5">
+              <h2 class="font-[Manrope,sans-serif] font-extrabold text-3xl text-dusk-text">
+                v{release.version}
+              </h2>
+              {release.tag && (
+                <span class="font-mono text-xs text-dusk-amber border border-dusk-amber px-2 py-0.5 uppercase tracking-widest">
+                  {release.tag}
+                </span>
+              )}
+              <time class="font-mono text-xs text-dusk-subtle" datetime={release.date}>
                 {new Date(release.date).toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "long",
@@ -39,10 +48,13 @@ const releases = [
                 })}
               </time>
             </div>
-            <ul class="change-list">
+            <ul class="flex flex-col gap-2 list-none p-0">
               {release.changes.map((change) => (
-                <li class="change-item">
-                  <span class="bullet" aria-hidden="true" />
+                <li class="flex gap-3 items-start font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed">
+                  <span
+                    class="inline-block w-1.5 h-1.5 rounded-full bg-dusk-amber flex-shrink-0 mt-1.5"
+                    aria-hidden="true"
+                  />
                   {change}
                 </li>
               ))}
@@ -53,84 +65,3 @@ const releases = [
     </div>
   </div>
 </MarketingLayout>
-
-<style>
-  .page-wrap {
-    max-width: 48rem;
-    margin: 0 auto;
-    padding: 4rem 1.5rem;
-  }
-
-  .page-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 4rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 2rem;
-  }
-
-  .releases {
-    display: flex;
-    flex-direction: column;
-    gap: 2.5rem;
-  }
-
-  .release-meta {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .version-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 2.5rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-  }
-
-  .release-tag {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    background: var(--brutal-yellow);
-    border: 3px solid var(--brutal-black);
-    padding: 0.15rem 0.5rem;
-  }
-
-  .release-date {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.8rem;
-    color: #666;
-  }
-
-  .change-list {
-    list-style: none;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .change-item {
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-    font-size: 0.875rem;
-    color: #333;
-    line-height: 1.6;
-  }
-
-  .bullet {
-    display: inline-block;
-    width: 0.6rem;
-    height: 0.6rem;
-    background: var(--brutal-yellow);
-    border: 1px solid var(--brutal-black);
-    flex-shrink: 0;
-    margin-top: 0.45rem;
-  }
-</style>

--- a/src/pages/docs.astro
+++ b/src/pages/docs.astro
@@ -21,78 +21,111 @@ const languages = [
 ---
 
 <MarketingLayout title="Docs — twish">
-  <div class="page-wrap">
-    <h1 class="page-heading">Documentation</h1>
+  <div class="max-w-2xl mx-auto px-6 py-16">
+    <p class="font-mono text-xs text-dusk-amber uppercase tracking-widest mb-4">Documentation</p>
+    <h1 class="font-[Manrope,sans-serif] font-extrabold text-4xl text-dusk-text mb-12">
+      Documentation
+    </h1>
 
     <!-- Quick start -->
-    <section class="doc-section">
-      <h2 class="section-heading">Quick start</h2>
-      <ol class="steps">
-        <li class="step">
-          <span class="step-num">1</span>
-          <span>
-            Go to <a href="/app" class="inline-link">twish/app</a> to open the diff tool.
-          </span>
-        </li>
-        <li class="step">
-          <span class="step-num">2</span>
-          <span
-            >Paste text into the <strong>Original</strong> and <strong>Modified</strong> panels — or drag
-            and drop files onto them.</span
-          >
-        </li>
-        <li class="step">
-          <span class="step-num">3</span>
-          <span
-            >Select the language for syntax highlighting using the dropdown above each panel.</span
-          >
-        </li>
-        <li class="step">
-          <span class="step-num">4</span>
-          <span
-            >Click <strong>Compare</strong> or press <kbd>Ctrl+Enter</kbd> to run the diff.
-          </span>
-        </li>
+    <section class="mb-10">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-lg text-dusk-text mb-4">Quick start</h2>
+      <ol class="flex flex-col gap-3 list-none p-0">
+        {
+          [
+            <>
+              Go to{" "}
+              <a
+                href="/app"
+                class="text-dusk-amber underline underline-offset-2 hover:text-dusk-text transition-colors"
+              >
+                twish/app
+              </a>{" "}
+              to open the diff tool.
+            </>,
+            <>
+              Paste text into the <strong class="text-dusk-text">Original</strong> and{" "}
+              <strong class="text-dusk-text">Modified</strong> panels — or drag and drop files onto
+              them.
+            </>,
+            <>Select the language for syntax highlighting using the dropdown above each panel.</>,
+            <>
+              Click <strong class="text-dusk-text">Compare</strong> or press{" "}
+              <kbd class="font-mono text-xs bg-dusk-surface text-dusk-muted border border-dusk-border px-1.5 py-0.5">
+                Ctrl+Enter
+              </kbd>{" "}
+              to run the diff.
+            </>,
+          ].map((content, i) => (
+            <li class="flex gap-3 items-start font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed">
+              <span class="flex items-center justify-center w-6 h-6 flex-shrink-0 bg-dusk-surface border border-dusk-amber font-mono text-xs text-dusk-amber">
+                {i + 1}
+              </span>
+              <span>{content}</span>
+            </li>
+          ))
+        }
       </ol>
     </section>
 
     <!-- Loading files -->
-    <section class="doc-section">
-      <h2 class="section-heading">Loading files</h2>
-      <div class="prose">
+    <section class="mb-10">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-lg text-dusk-text mb-4">Loading files</h2>
+      <div
+        class="flex flex-col gap-3 font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed"
+      >
         <p>
-          <strong>Drag & drop</strong> — drag any text file from your file manager and drop it onto either
-          editor panel. The file content will load into that panel.
+          <strong class="text-dusk-text">Drag & drop</strong> — drag any text file from your file manager
+          and drop it onto either editor panel. The file content will load into that panel.
         </p>
         <p>
-          <strong>File picker</strong> — click the <strong>Open File</strong> button below each panel,
-          or press <kbd>Ctrl+O</kbd> when a panel is focused.
+          <strong class="text-dusk-text">File picker</strong> — click the{" "}
+          <strong class="text-dusk-text">Open File</strong> button below each panel, or press{" "}
+          <kbd
+            class="font-mono text-xs bg-dusk-surface text-dusk-muted border border-dusk-border px-1.5 py-0.5"
+          >
+            Ctrl+O
+          </kbd>{" "}
+          when a panel is focused.
         </p>
         <p>
-          <strong>Paste</strong> — click into any panel and paste text directly from the clipboard.
+          <strong class="text-dusk-text">Paste</strong> — click into any panel and paste text directly
+          from the clipboard.
         </p>
       </div>
     </section>
 
     <!-- Keyboard shortcuts -->
-    <section class="doc-section">
-      <h2 class="section-heading">Keyboard shortcuts</h2>
-      <div class="table-wrap">
-        <table class="shortcuts-table">
+    <section class="mb-10">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-lg text-dusk-text mb-4">
+        Keyboard shortcuts
+      </h2>
+      <div class="border border-dusk-border overflow-hidden">
+        <table class="w-full border-collapse font-[Manrope,sans-serif] text-sm">
           <thead>
-            <tr class="table-header-row">
-              <th class="table-th">Shortcut</th>
-              <th class="table-th">Action</th>
+            <tr class="bg-dusk-surface border-b border-dusk-border">
+              <th
+                class="px-4 py-2.5 text-left font-mono text-xs text-dusk-amber uppercase tracking-widest"
+              >
+                Shortcut
+              </th>
+              <th
+                class="px-4 py-2.5 text-left font-mono text-xs text-dusk-amber uppercase tracking-widest"
+              >
+                Action
+              </th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="divide-y divide-dusk-border">
             {
               shortcuts.map((s) => (
-                <tr class="table-row">
-                  <td class="table-td">
-                    <kbd>{s.keys}</kbd>
+                <tr>
+                  <td class="px-4 py-3">
+                    <kbd class="font-mono text-xs bg-dusk-surface text-dusk-muted border border-dusk-border px-1.5 py-0.5">
+                      {s.keys}
+                    </kbd>
                   </td>
-                  <td class="table-td">{s.action}</td>
+                  <td class="px-4 py-3 text-dusk-muted">{s.action}</td>
                 </tr>
               ))
             }
@@ -102,17 +135,29 @@ const languages = [
     </section>
 
     <!-- Supported languages -->
-    <section class="doc-section">
-      <h2 class="section-heading">Supported languages</h2>
-      <div class="lang-list">
-        {languages.map((lang) => <span class="lang-tag">{lang}</span>)}
+    <section class="mb-10">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-lg text-dusk-text mb-4">
+        Supported languages
+      </h2>
+      <div class="flex flex-wrap gap-2">
+        {
+          languages.map((lang) => (
+            <span class="font-mono text-xs text-dusk-muted border border-dusk-border px-2.5 py-1 bg-dusk-surface uppercase tracking-wide">
+              {lang}
+            </span>
+          ))
+        }
       </div>
     </section>
 
     <!-- Install as PWA -->
-    <section class="doc-section">
-      <h2 class="section-heading">Install as a PWA</h2>
-      <div class="prose">
+    <section class="mb-10">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-lg text-dusk-text mb-4">
+        Install as a PWA
+      </h2>
+      <div
+        class="flex flex-col gap-3 font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed"
+      >
         <p>
           twish can be installed as a desktop or mobile app, and will work completely offline after
           installation.
@@ -126,147 +171,3 @@ const languages = [
     </section>
   </div>
 </MarketingLayout>
-
-<style>
-  .page-wrap {
-    max-width: 48rem;
-    margin: 0 auto;
-    padding: 4rem 1.5rem;
-  }
-
-  .page-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 4rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 2rem;
-  }
-
-  .doc-section {
-    margin-bottom: 3rem;
-  }
-
-  .section-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 1.75rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 1rem;
-  }
-
-  .steps {
-    list-style: none;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .step {
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-    font-size: 0.9rem;
-    color: #333;
-    line-height: 1.6;
-  }
-
-  .step-num {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    background: var(--brutal-yellow);
-    border: 3px solid var(--brutal-black);
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    flex-shrink: 0;
-  }
-
-  .prose {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    font-size: 0.9rem;
-    color: #333;
-    line-height: 1.6;
-  }
-
-  kbd {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.8rem;
-    background: var(--brutal-white);
-    border: 3px solid var(--brutal-black);
-    padding: 0.1rem 0.4rem;
-  }
-
-  .inline-link {
-    color: var(--brutal-black);
-    border-bottom: 2px solid var(--brutal-black);
-    text-decoration: none;
-  }
-
-  .inline-link:hover {
-    background: var(--brutal-yellow);
-  }
-
-  .table-wrap {
-    border: 3px solid var(--brutal-black);
-    overflow: hidden;
-  }
-
-  .shortcuts-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9rem;
-  }
-
-  .table-header-row {
-    background: var(--brutal-yellow);
-    border-bottom: 3px solid var(--brutal-black);
-  }
-
-  .table-th {
-    padding: 0.75rem 1rem;
-    text-align: left;
-    font-family: "IBM Plex Mono", monospace;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    font-size: 0.75rem;
-    color: var(--brutal-black);
-  }
-
-  .table-row {
-    border-bottom: 3px solid var(--brutal-black);
-  }
-
-  .table-row:last-child {
-    border-bottom: none;
-  }
-
-  .table-td {
-    padding: 0.75rem 1rem;
-    color: #333;
-  }
-
-  .lang-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .lang-tag {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    border: 3px solid var(--brutal-black);
-    padding: 0.2rem 0.6rem;
-    background: var(--brutal-white);
-    color: var(--brutal-black);
-  }
-</style>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -95,20 +95,31 @@ const features = [
 ---
 
 <MarketingLayout title="Features — twish">
-  <div class="page-wrap">
-    <h1 class="page-heading">Features</h1>
-    <p class="page-sub">Everything twish can do — and what's coming next.</p>
+  <div class="max-w-3xl mx-auto px-6 py-16">
+    <p class="font-mono text-xs text-dusk-amber uppercase tracking-widest mb-4">Features</p>
+    <h1 class="font-[Manrope,sans-serif] font-extrabold text-4xl text-dusk-text mb-3">
+      What twish can do
+    </h1>
+    <p class="font-[Manrope,sans-serif] text-dusk-muted mb-12">
+      Everything twish can do — and what's coming next.
+    </p>
 
-    <div class="sections">
+    <div class="flex flex-col gap-10">
       {
         features.map((section) => (
-          <div class="section">
-            <div class="category-label">{section.category}</div>
-            <div class="item-list">
+          <div>
+            <span class="inline-block font-mono text-xs text-dusk-amber uppercase tracking-widest border border-dusk-amber px-2 py-0.5 mb-4">
+              {section.category}
+            </span>
+            <div class="border border-dusk-border divide-y divide-dusk-border">
               {section.items.map((item) => (
-                <div class="item">
-                  <h3 class="item-title">{item.title}</h3>
-                  <p class="item-desc">{item.description}</p>
+                <div class="px-5 py-4">
+                  <h3 class="font-[Manrope,sans-serif] font-semibold text-sm text-dusk-text uppercase tracking-wide mb-1">
+                    {item.title}
+                  </h3>
+                  <p class="font-[Manrope,sans-serif] text-sm text-dusk-muted leading-relaxed">
+                    {item.description}
+                  </p>
                 </div>
               ))}
             </div>
@@ -118,73 +129,3 @@ const features = [
     </div>
   </div>
 </MarketingLayout>
-
-<style>
-  .page-wrap {
-    max-width: 56rem;
-    margin: 0 auto;
-    padding: 4rem 1.5rem;
-  }
-
-  .page-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 4rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 0.5rem;
-  }
-
-  .page-sub {
-    font-size: 0.9rem;
-    color: #444;
-    margin-bottom: 3rem;
-  }
-
-  .sections {
-    display: flex;
-    flex-direction: column;
-    gap: 3rem;
-  }
-
-  .category-label {
-    display: inline-block;
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    background: var(--brutal-yellow);
-    border: 3px solid var(--brutal-black);
-    padding: 0.2rem 0.6rem;
-    margin-bottom: 1rem;
-  }
-
-  .item-list {
-    border: 3px solid var(--brutal-black);
-  }
-
-  .item {
-    padding: 1rem 1.25rem;
-    border-bottom: 3px solid var(--brutal-black);
-  }
-
-  .item:last-child {
-    border-bottom: none;
-  }
-
-  .item-title {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.875rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--brutal-black);
-    margin-bottom: 0.35rem;
-  }
-
-  .item-desc {
-    font-size: 0.85rem;
-    color: #444;
-    line-height: 1.6;
-  }
-</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,11 +51,12 @@ const features = [
 <MarketingLayout title="twish — offline file diff tool">
   <Hero />
 
-  <!-- Feature grid -->
-  <section class="features-section">
-    <div class="features-inner">
-      <h2 class="features-heading">Everything you need to diff</h2>
-      <div class="features-grid">
+  <section class="px-6 pb-24">
+    <div class="max-w-5xl mx-auto">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-2xl text-dusk-text mb-8">
+        Everything you need to diff
+      </h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-px bg-dusk-border">
         {
           features.map((f) => (
             <FeatureCard title={f.title} description={f.description} icon={f.icon} num={f.num} />
@@ -65,103 +66,20 @@ const features = [
     </div>
   </section>
 
-  <!-- CTA -->
-  <section class="cta-section">
-    <div class="cta-inner">
-      <h2 class="cta-heading">Ready to compare?</h2>
-      <p class="cta-sub">No sign-up. No server. Just paste, drop, and diff.</p>
-      <a href="/app" class="cta-btn">Open the diff tool</a>
+  <section class="border-t border-dusk-border px-6 py-20">
+    <div class="max-w-lg mx-auto">
+      <h2 class="font-[Manrope,sans-serif] font-bold text-3xl text-dusk-text mb-3">
+        Ready to compare?
+      </h2>
+      <p class="font-[Manrope,sans-serif] text-dusk-muted mb-8">
+        No sign-up. No server. Just paste, drop, and diff.
+      </p>
+      <a
+        href="/app"
+        class="inline-block font-[Manrope,sans-serif] text-sm font-semibold text-dusk-amber border border-dusk-amber hover:bg-dusk-amber hover:text-dusk-bg transition-colors px-6 py-3 no-underline"
+      >
+        Open the diff tool
+      </a>
     </div>
   </section>
 </MarketingLayout>
-
-<style>
-  .features-section {
-    padding: 0 1.5rem 6rem;
-  }
-
-  .features-inner {
-    max-width: 64rem;
-    margin: 0 auto;
-  }
-
-  .features-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 2.5rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 2rem;
-  }
-
-  .features-grid {
-    display: grid;
-    gap: 1rem;
-    grid-template-columns: 1fr;
-  }
-
-  @media (min-width: 640px) {
-    .features-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .features-grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  .cta-section {
-    border-top: 3px solid var(--brutal-black);
-    padding: 5rem 1.5rem;
-  }
-
-  .cta-inner {
-    max-width: 36rem;
-    margin: 0 auto;
-  }
-
-  .cta-heading {
-    font-family: "Bebas Neue", sans-serif;
-    font-size: 3rem;
-    letter-spacing: 0.05em;
-    color: var(--brutal-black);
-    margin-bottom: 0.75rem;
-  }
-
-  .cta-sub {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.9rem;
-    color: #444;
-    margin-bottom: 2rem;
-  }
-
-  .cta-btn {
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.9rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    text-decoration: none;
-    padding: 0.75rem 1.75rem;
-    background: var(--brutal-black);
-    color: var(--brutal-white);
-    border: 3px solid var(--brutal-black);
-    box-shadow: var(--brutal-shadow);
-    display: inline-block;
-    transition:
-      transform 0.15s,
-      box-shadow 0.15s;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .cta-btn {
-      transition: none;
-    }
-  }
-
-  .cta-btn:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--brutal-black);
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,150 @@
 @import "tailwindcss";
 
-:root {
-  --brutal-black: #000000;
-  --brutal-white: #ffffff;
-  --brutal-yellow: #ffe600;
-  --brutal-shadow: 4px 4px 0 #000;
-  --brutal-shadow-sm: 2px 2px 0 #000;
+@theme {
+  --color-dusk-bg: #16120e;
+  --color-dusk-surface: #1f1a14;
+  --color-dusk-border: #3a3025;
+  --color-dusk-text: #f5ede0;
+  --color-dusk-muted: #9c8b78;
+  --color-dusk-subtle: #5c5048;
+  --color-dusk-amber: #e8963d;
+  --font-manrope: "Manrope", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+}
+
+@layer components {
+  /* ── App shell ───────────────────────────────────────── */
+  .diff-app {
+    @apply flex flex-col h-full overflow-hidden;
+  }
+  .diff-editors {
+    @apply flex flex-1 min-h-0 overflow-hidden;
+  }
+  .diff-panel {
+    @apply flex-1 min-h-0 flex flex-col;
+  }
+  .diff-panel--right {
+    @apply border-l border-dusk-border;
+  }
+  .diff-output {
+    @apply flex-1 min-h-0 overflow-auto border-t border-dusk-border;
+  }
+  .diff-hint {
+    @apply flex-shrink-0 flex items-center justify-center p-5 font-mono text-xs text-dusk-subtle;
+  }
+
+  /* ── Toolbar ─────────────────────────────────────────── */
+  .toolbar {
+    @apply flex items-center gap-2 flex-shrink-0 px-4 py-2 bg-dusk-surface border-b border-dusk-border;
+  }
+  .btn-compare {
+    @apply flex items-center gap-2 bg-transparent text-dusk-amber border border-dusk-amber hover:bg-dusk-amber hover:text-dusk-bg transition-colors px-3 py-1.5 font-sans text-sm font-semibold cursor-pointer;
+  }
+  .btn-secondary {
+    @apply bg-transparent text-dusk-muted border border-dusk-border hover:text-dusk-text hover:border-dusk-muted transition-colors px-3 py-1.5 font-sans text-sm font-medium cursor-pointer;
+  }
+  .kbd {
+    @apply font-mono text-[0.6rem] bg-dusk-bg text-dusk-subtle border border-dusk-border px-1.5 py-0.5;
+  }
+
+  /* ── Editor panel ────────────────────────────────────── */
+  .editor-panel {
+    @apply flex flex-col flex-1 min-h-0 border border-dusk-border overflow-hidden;
+  }
+  .editor-header {
+    @apply flex items-center justify-between flex-shrink-0 px-3 py-2 bg-dusk-surface border-b border-dusk-border;
+  }
+  .editor-label {
+    @apply font-mono text-xs uppercase tracking-widest text-dusk-muted;
+  }
+  .editor-drop-zone {
+    @apply relative flex-1 min-h-0;
+  }
+  .editor-drop-overlay {
+    @apply absolute inset-0 z-10 flex items-center justify-center bg-amber-500/20 border-2 border-dashed border-dusk-amber pointer-events-none;
+  }
+  .editor-drop-label {
+    @apply font-mono text-sm uppercase tracking-widest text-dusk-amber;
+  }
+  .editor-cm-host {
+    @apply h-full;
+  }
+  .editor-footer {
+    @apply flex-shrink-0 px-3 py-2 bg-dusk-surface border-t border-dusk-border;
+  }
+  .editor-open-btn {
+    @apply font-mono text-xs text-dusk-subtle hover:text-dusk-muted underline underline-offset-2 bg-transparent border-none cursor-pointer;
+  }
+  .lang-select {
+    @apply font-mono text-xs bg-dusk-bg text-dusk-muted border border-dusk-border px-2 py-1 cursor-pointer outline-none focus:border-dusk-amber;
+  }
+
+  /* ── Diff output ─────────────────────────────────────── */
+  .diff-empty {
+    @apply flex items-center justify-center p-12 font-mono text-sm text-dusk-muted;
+  }
+  .diff-wrap {
+    @apply flex flex-col min-h-0;
+  }
+  .diff-stats {
+    @apply flex items-center gap-4 flex-shrink-0 px-4 py-1.5 bg-dusk-surface border-b border-dusk-border font-mono text-xs;
+  }
+  .diff-stats-label {
+    @apply font-bold tracking-widest text-dusk-muted uppercase;
+  }
+  .diff-added {
+    @apply text-green-400 font-bold;
+  }
+  .diff-removed {
+    @apply text-red-400 font-bold;
+  }
+  .diff-identical {
+    @apply text-dusk-subtle;
+  }
+  .diff-table-wrap {
+    @apply flex-1 overflow-auto font-mono text-xs;
+  }
+  .diff-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .col-linenum {
+    width: 2.5rem;
+  }
+  .col-content {
+    width: calc(50% - 2.5rem);
+  }
+  .diff-row {
+    @apply border-b border-dusk-border/30;
+  }
+  .diff-linenum {
+    @apply select-none px-2 py-0.5 text-right text-dusk-subtle bg-dusk-surface whitespace-nowrap;
+  }
+  .diff-linenum--removed {
+    @apply bg-red-950/50 text-red-400;
+  }
+  .diff-linenum--added {
+    @apply bg-green-950/40 text-green-400;
+  }
+  .diff-content {
+    @apply px-3 py-0.5 whitespace-pre text-dusk-text;
+  }
+  .diff-content--removed {
+    @apply bg-red-950/40 text-red-300;
+  }
+  .diff-content--added {
+    @apply bg-green-950/30 text-green-300;
+  }
+  .diff-cell--empty {
+    @apply bg-dusk-bg;
+  }
+  .diff-marker {
+    @apply mr-1.5 font-bold;
+  }
+  .diff-marker--removed {
+    @apply text-red-400;
+  }
+  .diff-marker--added {
+    @apply text-green-400;
+  }
 }


### PR DESCRIPTION
## Summary

- Applies Dusk dark-amber design system to all layouts and marketing pages (warm dark amber palette with Manrope + JetBrains Mono fonts)
- Replaces `/app` with Live Split UX: 3-column auto-diff, 400ms debounce, no compare button needed
- Adds "changes only" toggle (default on): hides equal lines, keeps ±3 context lines around changes
- Adds "↓ Next" navigation button in diff panel to cycle through changed rows

## Changes

**Commit 1 — styles**: Dusk `@theme` tokens + full component class library in `global.css`

**Commit 2 — design**: Rewrote `MarketingLayout`, `AppLayout`, `Header`, `Footer`, `Hero`, `FeatureCard` with Dusk theme

**Commit 3 — pages**: Migrated `/`, `/features`, `/about`, `/docs`, `/changelog` to Dusk design

**Commit 4 — app**: Replaced `DiffApp.tsx` with Live Split UX (3-column, auto-diff, changes-only toggle, jump nav)

## Test plan

- [ ] `bun run type-check` — passes clean
- [ ] `bun run lint` — passes clean
- [ ] `bun run build` — 6 pages built (`/`, `/features`, `/about`, `/docs`, `/changelog`, `/app`)
- [ ] `/app` auto-diffs on paste (no compare button)
- [ ] Changes-only toggle hides equal lines, keeps ±3 context
- [ ] "↓ Next" scrolls to next changed row
- [ ] Swap ⇄ and Clear work; `Ctrl+Shift+C` clears
- [ ] `⟳ updating…` indicator visible during debounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)