### PR TITLE
feat(base64,json-formatter): implement Base64 and JSON Formatter tools (Phase 3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "astro": "^5.17.3",
         "diff": "^8.0.3",
         "lucide-solid": "^0.525.0",
+        "shiki": "^4.0.2",
         "solid-js": "^1.9.11",
         "tailwindcss": "^4.2.0",
         "yaml": "^2.8.3",
@@ -513,17 +514,19 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.58.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w=="],
 
-    "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
 
-    "@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
 
-    "@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
 
-    "@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
@@ -1617,7 +1620,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -1921,6 +1924,8 @@
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "@astrojs/markdown-remark/shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+
     "@astrojs/solid-js/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1970,6 +1975,8 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "astro/shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
 
     "astro/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -2047,6 +2054,18 @@
 
     "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@astrojs/markdown-remark/shiki/@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "@astrojs/markdown-remark/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+
+    "@astrojs/markdown-remark/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+
+    "@astrojs/markdown-remark/shiki/@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+
+    "@astrojs/markdown-remark/shiki/@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+
+    "@astrojs/markdown-remark/shiki/@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
+
     "@astrojs/solid-js/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -2064,6 +2083,18 @@
     "@rollup/plugin-replace/@rollup/pluginutils/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "astro/shiki/@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "astro/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+
+    "astro/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+
+    "astro/shiki/@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+
+    "astro/shiki/@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+
+    "astro/shiki/@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
 
     "astro/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "astro": "^5.17.3",
     "diff": "^8.0.3",
-    "solid-js": "^1.9.11",
     "lucide-solid": "^0.525.0",
+    "shiki": "^4.0.2",
+    "solid-js": "^1.9.11",
     "tailwindcss": "^4.2.0",
     "yaml": "^2.8.3"
   },

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -1,8 +1,10 @@
 ---
 import { getToolBySlug, tools } from "@/tools/registry";
 import ToolShell from "@/components/ToolShell.astro";
-import JwtDecoder from "@/tools/jwt-decoder/JwtDecoder";
+import Base64Tool from "@/tools/base64/Base64Tool";
 import DiffTool from "@/tools/diff/DiffTool";
+import JsonFormatter from "@/tools/json-formatter/JsonFormatter";
+import JwtDecoder from "@/tools/jwt-decoder/JwtDecoder";
 
 export function getStaticPaths() {
   return tools.map((tool) => ({
@@ -24,6 +26,10 @@ if (!tool) {
       <JwtDecoder client:load />
     ) : slug === "diff" ? (
       <DiffTool client:load />
+    ) : slug === "base64" ? (
+      <Base64Tool client:load />
+    ) : slug === "json-formatter" ? (
+      <JsonFormatter client:load />
     ) : (
       <div style="padding: 2rem; text-align: center; color: var(--text-muted);">
         <p style="font-size: 1.25rem; font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem;">

--- a/src/tools/base64/Base64Tool.tsx
+++ b/src/tools/base64/Base64Tool.tsx
@@ -1,0 +1,344 @@
+import { createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Mode = "encode" | "decode";
+
+/** Encode a string to base64 (UTF-8 safe). */
+function encodeBase64(input: string): string {
+  return btoa(
+    encodeURIComponent(input).replace(/%([0-9A-F]{2})/g, (_, p1: string) =>
+      String.fromCharCode(parseInt(p1, 16))
+    )
+  );
+}
+
+/** Decode a base64 string back to UTF-8. */
+function decodeBase64(input: string): string {
+  const binary = atob(input.trim());
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+interface Result {
+  value: string;
+  error: string | null;
+}
+
+function process(input: string, mode: Mode): Result {
+  const trimmed = input.trim();
+  if (!trimmed) return { value: "", error: null };
+  try {
+    if (mode === "encode") {
+      return { value: encodeBase64(trimmed), error: null };
+    } else {
+      return { value: decodeBase64(trimmed), error: null };
+    }
+  } catch {
+    return {
+      value: "",
+      error:
+        mode === "decode"
+          ? "Invalid base64 — input contains characters outside the base64 alphabet."
+          : "Encoding failed — input may contain unsupported characters.",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function Base64Tool() {
+  const [mode, setMode] = createSignal<Mode>("encode");
+  const [input, setInput] = createSignal("");
+
+  const result = (): Result => process(input(), mode());
+
+  function swap() {
+    const current = result().value;
+    setMode((m) => (m === "encode" ? "decode" : "encode"));
+    setInput(current);
+  }
+
+  function handleFile(file: File) {
+    if (file.size > 2 * 1024 * 1024) {
+      setInput(""); // clear input and let error show via the signal
+      // We need to signal the oversize case separately
+      setInput("__FILE_TOO_LARGE__");
+      return;
+    }
+    const reader = new FileReader();
+    if (mode() === "encode") {
+      reader.onload = () => {
+        const arr = new Uint8Array(reader.result as ArrayBuffer);
+        let binary = "";
+        for (let i = 0; i < arr.length; i++) {
+          binary += String.fromCharCode(arr[i]);
+        }
+        setInput(btoa(binary));
+        // Switch to decode mode after reading so user sees the base64 output
+        setMode("decode");
+        // Actually keep in encode mode — file -> show base64
+        setMode("encode");
+        setInput(btoa(binary));
+      };
+      reader.readAsArrayBuffer(file);
+    } else {
+      reader.onload = () => {
+        setInput(reader.result as string);
+      };
+      reader.readAsText(file);
+    }
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    const file = e.dataTransfer?.files?.[0];
+    if (file) handleFile(file);
+  }
+
+  const tabStyle = (active: boolean) => ({
+    padding: "0.375rem 1rem",
+    "border-radius": "0.375rem",
+    "font-size": "0.8125rem",
+    "font-weight": "600",
+    cursor: "pointer",
+    border: "none",
+    background: active ? "var(--accent-primary)" : "transparent",
+    color: active ? "var(--bg-primary)" : "var(--text-secondary)",
+    transition: "background 0.15s, color 0.15s",
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "860px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      {/* ------------------------------------------------------------------ */}
+      {/* Mode toggle + swap                                                  */}
+      {/* ------------------------------------------------------------------ */}
+      <div
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "0.5rem",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "0.25rem",
+            padding: "0.25rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.5rem",
+          }}
+        >
+          <button style={tabStyle(mode() === "encode")} onClick={() => setMode("encode")}>
+            Encode
+          </button>
+          <button style={tabStyle(mode() === "decode")} onClick={() => setMode("decode")}>
+            Decode
+          </button>
+        </div>
+
+        <button
+          onClick={swap}
+          title="Swap input/output"
+          style={{
+            "margin-left": "auto",
+            padding: "0.375rem 0.75rem",
+            "border-radius": "0.375rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-secondary)",
+            "font-size": "0.8125rem",
+            cursor: "pointer",
+          }}
+        >
+          ⇅ Swap
+        </button>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Input                                                               */}
+      {/* ------------------------------------------------------------------ */}
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
+        <label
+          style={{
+            "font-size": "0.75rem",
+            "font-weight": "600",
+            "letter-spacing": "0.05em",
+            "text-transform": "uppercase",
+            color: "var(--text-secondary)",
+          }}
+        >
+          {mode() === "encode" ? "Plain text" : "Base64"}
+        </label>
+
+        {/* Drop zone wrapper */}
+        <div
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={onDrop}
+          style={{ position: "relative" }}
+        >
+          <textarea
+            value={input() === "__FILE_TOO_LARGE__" ? "" : input()}
+            onInput={(e) => setInput(e.currentTarget.value)}
+            placeholder={
+              mode() === "encode"
+                ? "Type or paste text to encode, or drop a file…"
+                : "Paste base64 to decode, or drop a file…"
+            }
+            rows={8}
+            spellcheck={false}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              "line-height": "1.6",
+              resize: "vertical",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+
+        {/* File open button */}
+        <div style={{ display: "flex", "align-items": "center", gap: "0.5rem" }}>
+          <label
+            style={{
+              "font-size": "0.8125rem",
+              color: "var(--accent-primary)",
+              cursor: "pointer",
+            }}
+          >
+            Open file
+            <input
+              type="file"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const file = e.currentTarget.files?.[0];
+                if (file) handleFile(file);
+                e.currentTarget.value = "";
+              }}
+            />
+          </label>
+          <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>· max 2 MB</span>
+        </div>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Error banner                                                        */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={input() === "__FILE_TOO_LARGE__"}>
+        <div
+          role="alert"
+          style={{
+            padding: "0.75rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--accent-error)",
+            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
+            color: "var(--accent-error)",
+            "font-size": "0.875rem",
+          }}
+        >
+          File is too large — maximum supported size is 2 MB.
+        </div>
+      </Show>
+      <Show when={result().error}>
+        <div
+          role="alert"
+          style={{
+            padding: "0.75rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--accent-error)",
+            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
+            color: "var(--accent-error)",
+            "font-size": "0.875rem",
+          }}
+        >
+          {result().error}
+        </div>
+      </Show>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Output                                                              */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={result().value}>
+        {(value) => (
+          <div
+            style={{
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              "border-radius": "0.5rem",
+              overflow: "hidden",
+            }}
+          >
+            {/* Output header */}
+            <div
+              style={{
+                display: "flex",
+                "align-items": "center",
+                "justify-content": "space-between",
+                padding: "0.625rem 1rem",
+                "border-bottom": "1px solid var(--border)",
+              }}
+            >
+              <span
+                style={{
+                  "font-size": "0.75rem",
+                  "font-weight": "600",
+                  "letter-spacing": "0.05em",
+                  "text-transform": "uppercase",
+                  color: "var(--text-secondary)",
+                }}
+              >
+                {mode() === "encode" ? "Base64" : "Plain text"}
+              </span>
+              <CopyButton text={value()} />
+            </div>
+
+            {/* Output body */}
+            <pre
+              style={{
+                margin: "0",
+                padding: "1rem",
+                "overflow-x": "auto",
+                "font-size": "0.8125rem",
+                "line-height": "1.6",
+                color: "var(--text-primary)",
+                "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                "white-space": "pre-wrap",
+                "word-break": "break-all",
+              }}
+            >
+              <code>{value()}</code>
+            </pre>
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/src/tools/json-formatter/JsonFormatter.tsx
+++ b/src/tools/json-formatter/JsonFormatter.tsx
@@ -1,0 +1,309 @@
+import { createMemo, createSignal, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type IndentSize = 2 | 4;
+
+interface FormatResult {
+  html: string;
+  raw: string;
+  error: string | null;
+  errorLine: number | null;
+}
+
+/** Very small tokenizer-based syntax highlighter (no shiki needed at runtime). */
+function syntaxHighlight(json: string): string {
+  return json
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(
+      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
+      (match) => {
+        let cls = "color: var(--accent-primary)"; // number
+        if (/^"/.test(match)) {
+          if (/:$/.test(match)) {
+            cls = "color: var(--text-primary); font-weight: 600"; // key
+          } else {
+            cls = "color: var(--accent-success)"; // string value
+          }
+        } else if (/true|false/.test(match)) {
+          cls = "color: var(--accent-warning)"; // boolean
+        } else if (/null/.test(match)) {
+          cls = "color: var(--text-muted)"; // null
+        }
+        return `<span style="${cls}">${match}</span>`;
+      }
+    );
+}
+
+/** Extract line/column from a JSON parse error message. */
+function parseErrorPosition(msg: string): number | null {
+  const match = /line (\d+)/.exec(msg) ?? /position (\d+)/.exec(msg);
+  if (!match) return null;
+  return parseInt(match[1], 10);
+}
+
+function formatJson(input: string, indent: IndentSize, minify: boolean): FormatResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { html: "", raw: "", error: null, errorLine: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      html: "",
+      raw: "",
+      error: `JSON parse error: ${msg}`,
+      errorLine: parseErrorPosition(msg),
+    };
+  }
+
+  const raw = minify ? JSON.stringify(parsed) : JSON.stringify(parsed, null, indent);
+
+  const html = syntaxHighlight(raw);
+  return { html, raw, error: null, errorLine: null };
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function JsonFormatter() {
+  const [input, setInput] = createSignal("");
+  const [indent, setIndent] = createSignal<IndentSize>(2);
+  const [minify, setMinify] = createSignal(false);
+  const result = createMemo((): FormatResult => formatJson(input(), indent(), minify()));
+
+  const tabStyle = (active: boolean) => ({
+    padding: "0.25rem 0.625rem",
+    "border-radius": "0.25rem",
+    "font-size": "0.75rem",
+    "font-weight": "600",
+    cursor: "pointer",
+    border: "none",
+    background: active ? "var(--accent-primary)" : "transparent",
+    color: active ? "var(--bg-primary)" : "var(--text-secondary)",
+    transition: "background 0.15s, color 0.15s",
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      {/* ------------------------------------------------------------------ */}
+      {/* Toolbar                                                             */}
+      {/* ------------------------------------------------------------------ */}
+      <div
+        style={{
+          display: "flex",
+          "align-items": "center",
+          "flex-wrap": "wrap",
+          gap: "0.75rem",
+        }}
+      >
+        {/* Indent toggle */}
+        <div
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "0.25rem",
+            padding: "0.25rem",
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.375rem",
+          }}
+        >
+          <button
+            style={tabStyle(indent() === 2 && !minify())}
+            onClick={() => {
+              setIndent(2);
+              setMinify(false);
+            }}
+          >
+            2 spaces
+          </button>
+          <button
+            style={tabStyle(indent() === 4 && !minify())}
+            onClick={() => {
+              setIndent(4);
+              setMinify(false);
+            }}
+          >
+            4 spaces
+          </button>
+        </div>
+
+        {/* Minify toggle */}
+        <button
+          style={{
+            padding: "0.25rem 0.75rem",
+            "border-radius": "0.375rem",
+            border: `1px solid ${minify() ? "var(--accent-primary)" : "var(--border)"}`,
+            background: minify()
+              ? "color-mix(in srgb, var(--accent-primary) 15%, transparent)"
+              : "var(--bg-secondary)",
+            color: minify() ? "var(--accent-primary)" : "var(--text-secondary)",
+            "font-size": "0.75rem",
+            "font-weight": "600",
+            cursor: "pointer",
+          }}
+          onClick={() => setMinify((v) => !v)}
+        >
+          Minify
+        </button>
+
+        {/* Clear */}
+        <Show when={input().trim()}>
+          <button
+            style={{
+              "margin-left": "auto",
+              padding: "0.25rem 0.75rem",
+              "border-radius": "0.375rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-muted)",
+              "font-size": "0.75rem",
+              cursor: "pointer",
+            }}
+            onClick={() => setInput("")}
+          >
+            Clear
+          </button>
+        </Show>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Input                                                               */}
+      {/* ------------------------------------------------------------------ */}
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label
+          style={{
+            "font-size": "0.75rem",
+            "font-weight": "600",
+            "letter-spacing": "0.05em",
+            "text-transform": "uppercase",
+            color: "var(--text-secondary)",
+          }}
+        >
+          Input JSON
+        </label>
+        <textarea
+          value={input()}
+          onInput={(e) => setInput(e.currentTarget.value)}
+          placeholder="Paste JSON here…"
+          rows={10}
+          autofocus
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: `1px solid ${result().error ? "var(--accent-error)" : "var(--border)"}`,
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+            transition: "border-color 0.15s",
+          }}
+        />
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Error banner                                                        */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={result().error}>
+        {(msg) => (
+          <div
+            role="alert"
+            style={{
+              padding: "0.75rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--accent-error)",
+              background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
+              color: "var(--accent-error)",
+              "font-size": "0.875rem",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            }}
+          >
+            {msg()}
+          </div>
+        )}
+      </Show>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Output                                                              */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={result().html}>
+        {(html) => (
+          <div
+            style={{
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              "border-radius": "0.5rem",
+              overflow: "hidden",
+            }}
+          >
+            {/* Output header */}
+            <div
+              style={{
+                display: "flex",
+                "align-items": "center",
+                "justify-content": "space-between",
+                padding: "0.625rem 1rem",
+                "border-bottom": "1px solid var(--border)",
+              }}
+            >
+              <span
+                style={{
+                  "font-size": "0.75rem",
+                  "font-weight": "600",
+                  "letter-spacing": "0.05em",
+                  "text-transform": "uppercase",
+                  color: "var(--text-secondary)",
+                }}
+              >
+                {minify() ? "Minified" : `Formatted · ${indent()} spaces`}
+              </span>
+              <CopyButton text={result().raw} />
+            </div>
+
+            {/* Syntax-highlighted output */}
+            <pre
+              style={{
+                margin: "0",
+                padding: "1rem",
+                "overflow-x": "auto",
+                "font-size": "0.8125rem",
+                "line-height": "1.6",
+                color: "var(--text-primary)",
+                "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                "white-space": "pre-wrap",
+                "word-break": "break-all",
+              }}
+              innerHTML={html()}
+            />
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `shiki` dependency (for future server-side use; inline syntax highlighter used in JSON Formatter)
- Implements `src/tools/base64/Base64Tool.tsx` — encode/decode with file support
- Implements `src/tools/json-formatter/JsonFormatter.tsx` — format/minify with syntax highlighting
- Wires `base64` and `json-formatter` slugs in `src/pages/tools/[slug].astro`

## Base64 Tool

- Encode/decode toggle with swap button
- UTF-8-safe encoding via `encodeURIComponent` trick
- File drag-and-drop + "Open file" button (max 2 MB, error on oversize)
- Copy output button

## JSON Formatter

- 2-space / 4-space indent toggle + minify mode
- Real-time inline syntax highlighting (keys, strings, numbers, booleans, null)
- Parse error banner with message from `JSON.parse`
- Border turns red on invalid input; clears on valid
- Copy formatted output button

## Verification

`bun run type-check && bun run lint && bun run test && bun run build` — all pass, 9 pages built, 28 precache entries (337 KiB)