### PR TITLE
feat(regex-tester): implement Regex Tester tool (Phase 5)

### DIFF
--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -6,6 +6,7 @@ import DiffTool from "@/tools/diff/DiffTool";
 import HashGenerator from "@/tools/hash-generator/HashGenerator";
 import JsonFormatter from "@/tools/json-formatter/JsonFormatter";
 import JwtDecoder from "@/tools/jwt-decoder/JwtDecoder";
+import RegexTester from "@/tools/regex-tester/RegexTester";
 import TimestampTool from "@/tools/timestamp/TimestampTool";
 import UuidGenerator from "@/tools/uuid-generator/UuidGenerator";
 
@@ -39,6 +40,8 @@ if (!tool) {
       <UuidGenerator client:load />
     ) : slug === "timestamp" ? (
       <TimestampTool client:load />
+    ) : slug === "regex-tester" ? (
+      <RegexTester client:load />
     ) : (
       <div style="padding: 2rem; text-align: center; color: var(--text-muted);">
         <p style="font-size: 1.25rem; font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem;">

--- a/src/tools/regex-tester/RegexTester.tsx
+++ b/src/tools/regex-tester/RegexTester.tsx
@@ -1,0 +1,570 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+
+import CopyButton from "@/components/CopyButton";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type FlagKey = "g" | "i" | "m" | "s";
+
+interface Flag {
+  key: FlagKey;
+  label: string;
+  title: string;
+}
+
+const ALL_FLAGS: Flag[] = [
+  { key: "g", label: "g", title: "Global — find all matches" },
+  { key: "i", label: "i", title: "Case-insensitive" },
+  { key: "m", label: "m", title: "Multiline — ^ and $ match line boundaries" },
+  { key: "s", label: "s", title: "Dot-all — . matches newlines" },
+];
+
+interface CaptureGroup {
+  name: string | null;
+  value: string;
+}
+
+interface MatchResult {
+  index: number;
+  fullMatch: string;
+  groups: CaptureGroup[];
+}
+
+interface RegexResult {
+  matches: MatchResult[];
+  highlighted: string; // HTML with <mark> tags
+  error: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function buildResult(pattern: string, flags: Set<FlagKey>, input: string): RegexResult {
+  if (!pattern) {
+    return { matches: [], highlighted: escapeHtml(input), error: null };
+  }
+
+  let regex: RegExp;
+  const flagStr = [...flags].join("");
+  try {
+    // Always add 'd' (indices) if supported, fallback gracefully
+    regex = new RegExp(pattern, flagStr.includes("g") ? flagStr : flagStr + "g");
+  } catch (err) {
+    return {
+      matches: [],
+      highlighted: escapeHtml(input),
+      error: err instanceof Error ? err.message : "Invalid regular expression",
+    };
+  }
+
+  const matches: MatchResult[] = [];
+  const allMatchRanges: [number, number][] = [];
+
+  let m: RegExpExecArray | null;
+  // Guard against infinite loops from zero-width matches
+  let lastIndex = -1;
+  while ((m = regex.exec(input)) !== null) {
+    if (m.index === lastIndex) {
+      regex.lastIndex++;
+      continue;
+    }
+    lastIndex = m.index;
+
+    const groups: CaptureGroup[] = [];
+    if (m.groups) {
+      for (const [name, value] of Object.entries(m.groups)) {
+        groups.push({ name, value: value ?? "" });
+      }
+    }
+    // Also push unnamed capture groups (indices 1+) that aren't named
+    for (let i = 1; i < m.length; i++) {
+      // Only add if not already covered by named groups
+      const alreadyNamed = m.groups && Object.values(m.groups).includes(m[i]);
+      if (!alreadyNamed && m[i] !== undefined) {
+        groups.push({ name: null, value: m[i] ?? "" });
+      }
+    }
+
+    matches.push({
+      index: m.index,
+      fullMatch: m[0],
+      groups,
+    });
+
+    allMatchRanges.push([m.index, m.index + m[0].length]);
+
+    if (!flagStr.includes("g")) break;
+  }
+
+  // Build highlighted HTML
+  let highlighted = "";
+  let pos = 0;
+  for (const [start, end] of allMatchRanges) {
+    highlighted += escapeHtml(input.slice(pos, start));
+    highlighted += `<mark style="background:color-mix(in srgb,var(--accent-primary) 30%,transparent);border-radius:2px;color:inherit;">${escapeHtml(input.slice(start, end))}</mark>`;
+    pos = end;
+  }
+  highlighted += escapeHtml(input.slice(pos));
+
+  return { matches, highlighted, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function RegexTester() {
+  const [pattern, setPattern] = createSignal("");
+  const [flags, setFlags] = createSignal<Set<FlagKey>>(new Set(["g"]));
+  const [input, setInput] = createSignal("");
+
+  function toggleFlag(key: FlagKey) {
+    setFlags((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  const result = createMemo((): RegexResult => buildResult(pattern(), flags(), input()));
+
+  const matchCount = createMemo(() => result().matches.length);
+
+  const namedGroupNames = createMemo((): string[] => {
+    const names = new Set<string>();
+    for (const m of result().matches) {
+      for (const g of m.groups) {
+        if (g.name) names.add(g.name);
+      }
+    }
+    return [...names];
+  });
+
+  const hasCaptures = createMemo(() => result().matches.some((m) => m.groups.length > 0));
+
+  const labelStyle = {
+    "font-size": "0.75rem",
+    "font-weight": "600" as const,
+    "letter-spacing": "0.05em",
+    "text-transform": "uppercase" as const,
+    color: "var(--text-secondary)",
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "1.25rem",
+        padding: "1.5rem",
+        "max-width": "900px",
+        margin: "0 auto",
+        width: "100%",
+      }}
+    >
+      {/* ------------------------------------------------------------------ */}
+      {/* Pattern input + flags                                               */}
+      {/* ------------------------------------------------------------------ */}
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
+        <label style={labelStyle}>Pattern</label>
+
+        {/* Pattern row */}
+        <div
+          style={{
+            display: "flex",
+            "align-items": "center",
+            background: "var(--bg-secondary)",
+            border: `1px solid ${result().error ? "var(--accent-error)" : "var(--border)"}`,
+            "border-radius": "0.5rem",
+            overflow: "hidden",
+            transition: "border-color 0.15s",
+          }}
+        >
+          {/* Opening slash */}
+          <span
+            style={{
+              padding: "0 0.5rem 0 0.875rem",
+              color: "var(--text-muted)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "1.125rem",
+              "user-select": "none",
+            }}
+          >
+            /
+          </span>
+
+          <input
+            type="text"
+            value={pattern()}
+            onInput={(e) => setPattern(e.currentTarget.value)}
+            placeholder="pattern"
+            spellcheck={false}
+            style={{
+              flex: "1",
+              padding: "0.625rem 0",
+              background: "transparent",
+              border: "none",
+              outline: "none",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.9375rem",
+            }}
+          />
+
+          {/* Closing slash */}
+          <span
+            style={{
+              color: "var(--text-muted)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "1.125rem",
+              "user-select": "none",
+            }}
+          >
+            /
+          </span>
+
+          {/* Flag toggles inline */}
+          <div
+            style={{
+              display: "flex",
+              "align-items": "center",
+              gap: "0.125rem",
+              padding: "0 0.75rem",
+            }}
+          >
+            <For each={ALL_FLAGS}>
+              {(flag) => (
+                <button
+                  title={flag.title}
+                  onClick={() => toggleFlag(flag.key)}
+                  style={{
+                    padding: "0.125rem 0.375rem",
+                    "border-radius": "0.25rem",
+                    border: "none",
+                    background: flags().has(flag.key) ? "var(--accent-primary)" : "transparent",
+                    color: flags().has(flag.key) ? "var(--bg-primary)" : "var(--text-muted)",
+                    "font-family":
+                      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                    "font-size": "0.875rem",
+                    "font-weight": "700",
+                    cursor: "pointer",
+                    transition: "background 0.1s, color 0.1s",
+                  }}
+                >
+                  {flag.label}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Error banner                                                        */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={result().error}>
+        {(msg) => (
+          <div
+            role="alert"
+            style={{
+              padding: "0.75rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--accent-error)",
+              background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
+              color: "var(--accent-error)",
+              "font-size": "0.875rem",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            }}
+          >
+            {msg()}
+          </div>
+        )}
+      </Show>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Test string input                                                   */}
+      {/* ------------------------------------------------------------------ */}
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+        <label style={labelStyle}>Test string</label>
+        <textarea
+          value={input()}
+          onInput={(e) => setInput(e.currentTarget.value)}
+          placeholder="Enter text to test against the pattern…"
+          rows={6}
+          spellcheck={false}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-primary)",
+            "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            "font-size": "0.875rem",
+            "line-height": "1.6",
+            resize: "vertical",
+            outline: "none",
+            "box-sizing": "border-box",
+          }}
+        />
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Highlighted output                                                  */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={input().trim()}>
+        <div
+          style={{
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.5rem",
+            overflow: "hidden",
+          }}
+        >
+          {/* Header with match count */}
+          <div
+            style={{
+              display: "flex",
+              "align-items": "center",
+              "justify-content": "space-between",
+              padding: "0.5rem 1rem",
+              "border-bottom": "1px solid var(--border)",
+            }}
+          >
+            <span style={labelStyle}>Matches</span>
+            <Show
+              when={pattern() && !result().error}
+              fallback={
+                <span
+                  style={{
+                    "font-size": "0.8125rem",
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  —
+                </span>
+              }
+            >
+              <span
+                style={{
+                  "font-size": "0.8125rem",
+                  "font-weight": "600",
+                  color: matchCount() > 0 ? "var(--accent-success)" : "var(--text-muted)",
+                }}
+              >
+                {matchCount() === 0
+                  ? "No matches"
+                  : matchCount() === 1
+                    ? "1 match"
+                    : `${matchCount()} matches`}
+              </span>
+            </Show>
+          </div>
+
+          {/* Highlighted text */}
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "overflow-x": "auto",
+              "font-size": "0.875rem",
+              "line-height": "1.8",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "white-space": "pre-wrap",
+              "word-break": "break-all",
+            }}
+            innerHTML={result().highlighted}
+          />
+        </div>
+      </Show>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Capture groups table                                                */}
+      {/* ------------------------------------------------------------------ */}
+      <Show when={hasCaptures() && matchCount() > 0}>
+        <div
+          style={{
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.5rem",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              padding: "0.5rem 1rem",
+              "border-bottom": "1px solid var(--border)",
+            }}
+          >
+            <span style={labelStyle}>Capture groups</span>
+          </div>
+
+          <div style={{ overflow: "auto" }}>
+            <table
+              style={{
+                width: "100%",
+                "border-collapse": "collapse",
+                "font-size": "0.8125rem",
+                "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              }}
+            >
+              <thead>
+                <tr>
+                  <th
+                    style={{
+                      padding: "0.5rem 1rem",
+                      "text-align": "left",
+                      color: "var(--text-muted)",
+                      "font-weight": "600",
+                      "border-bottom": "1px solid var(--border)",
+                      "white-space": "nowrap",
+                    }}
+                  >
+                    Match #
+                  </th>
+                  <th
+                    style={{
+                      padding: "0.5rem 1rem",
+                      "text-align": "left",
+                      color: "var(--text-muted)",
+                      "font-weight": "600",
+                      "border-bottom": "1px solid var(--border)",
+                    }}
+                  >
+                    Full match
+                  </th>
+                  <Show when={namedGroupNames().length > 0}>
+                    <For each={namedGroupNames()}>
+                      {(name) => (
+                        <th
+                          style={{
+                            padding: "0.5rem 1rem",
+                            "text-align": "left",
+                            color: "var(--accent-primary)",
+                            "font-weight": "600",
+                            "border-bottom": "1px solid var(--border)",
+                            "white-space": "nowrap",
+                          }}
+                        >
+                          {name}
+                        </th>
+                      )}
+                    </For>
+                  </Show>
+                  <Show when={result().matches.some((m) => m.groups.some((g) => g.name === null))}>
+                    <th
+                      style={{
+                        padding: "0.5rem 1rem",
+                        "text-align": "left",
+                        color: "var(--text-muted)",
+                        "font-weight": "600",
+                        "border-bottom": "1px solid var(--border)",
+                      }}
+                    >
+                      Groups
+                    </th>
+                  </Show>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={result().matches}>
+                  {(match, i) => (
+                    <tr>
+                      <td
+                        style={{
+                          padding: "0.375rem 1rem",
+                          color: "var(--text-muted)",
+                          "border-bottom": "1px solid var(--border)",
+                          "white-space": "nowrap",
+                        }}
+                      >
+                        {i() + 1}
+                      </td>
+                      <td
+                        style={{
+                          padding: "0.375rem 1rem",
+                          color: "var(--text-primary)",
+                          "border-bottom": "1px solid var(--border)",
+                          "max-width": "200px",
+                          overflow: "hidden",
+                          "text-overflow": "ellipsis",
+                          "white-space": "nowrap",
+                        }}
+                      >
+                        <div style={{ display: "flex", "align-items": "center", gap: "0.5rem" }}>
+                          <span
+                            style={{ flex: "1", overflow: "hidden", "text-overflow": "ellipsis" }}
+                          >
+                            {match.fullMatch}
+                          </span>
+                          <CopyButton text={match.fullMatch} />
+                        </div>
+                      </td>
+                      <Show when={namedGroupNames().length > 0}>
+                        <For each={namedGroupNames()}>
+                          {(name) => {
+                            const g = match.groups.find((gr) => gr.name === name);
+                            return (
+                              <td
+                                style={{
+                                  padding: "0.375rem 1rem",
+                                  color: g ? "var(--accent-success)" : "var(--text-muted)",
+                                  "border-bottom": "1px solid var(--border)",
+                                }}
+                              >
+                                {g ? g.value : "—"}
+                              </td>
+                            );
+                          }}
+                        </For>
+                      </Show>
+                      <Show when={match.groups.some((g) => g.name === null)}>
+                        <td
+                          style={{
+                            padding: "0.375rem 1rem",
+                            color: "var(--text-primary)",
+                            "border-bottom": "1px solid var(--border)",
+                          }}
+                        >
+                          {match.groups
+                            .filter((g) => g.name === null)
+                            .map((g) => g.value)
+                            .join(", ")}
+                        </td>
+                      </Show>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Show>
+
+      {/* Empty state */}
+      <Show when={!pattern() && !input().trim()}>
+        <p
+          style={{
+            "font-size": "0.8125rem",
+            color: "var(--text-muted)",
+            margin: "0",
+          }}
+        >
+          Enter a regex pattern and test string — matches are highlighted in real time
+        </p>
+      </Show>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Implements `src/tools/regex-tester/RegexTester.tsx` — full-featured regex tester
- Wires `regex-tester` slug in `[slug].astro`
- Completes all 8 planned tools across Phases 0–5

## Features

- Pattern input with embedded `/…/flags` UI — opening and closing slashes are decorative, flags are toggleable buttons inline
- Flag toggles: `g` (global), `i` (case-insensitive), `m` (multiline), `s` (dot-all)
- Real-time match highlighting in output pane — matches highlighted with `<mark>` using `innerHTML` on a `<pre>`
- Match count badge (green on hits, muted on zero)
- Invalid regex shows red error banner, never crashes
- Capture groups table with named group columns + unnamed group fallback
- Per-match copy button for full match text
- Zero-width match protection to prevent infinite loops

## Verification

`bun run type-check && bun run lint && bun run test && bun run build` — all pass, 9 pages, 32 precache entries (385 KiB)