### PR TITLE
feat(platform): unify local file import handling for diff and base64 tools

### DIFF
--- a/src/lib/fileImport.test.ts
+++ b/src/lib/fileImport.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_IMPORT_MAX_BYTES,
+  DEFAULT_IMPORT_WARN_BYTES,
+  evaluateFileImportPolicy,
+  formatBytes,
+  readImportedFile,
+} from "./fileImport";
+
+describe("file import utilities", () => {
+  it("accepts files below the warning threshold", () => {
+    expect(evaluateFileImportPolicy({ size: 1024 })).toEqual({ status: "accept" });
+  });
+
+  it("returns a warning decision for files above the warning threshold", () => {
+    expect(evaluateFileImportPolicy({ size: DEFAULT_IMPORT_WARN_BYTES + 1 })).toEqual({
+      status: "warn",
+      warnBytes: DEFAULT_IMPORT_WARN_BYTES,
+    });
+  });
+
+  it("rejects files above the maximum threshold", () => {
+    expect(evaluateFileImportPolicy({ size: DEFAULT_IMPORT_MAX_BYTES + 1 })).toEqual({
+      status: "reject",
+      maxBytes: DEFAULT_IMPORT_MAX_BYTES,
+    });
+  });
+
+  it("reads text files and keeps the size decision", async () => {
+    const file = new File(["hello world"], "hello.txt", { type: "text/plain" });
+    const result = await readImportedFile(file, { as: "text" });
+
+    expect(result).toEqual({
+      ok: true,
+      file: {
+        name: "hello.txt",
+        size: 11,
+        type: "text/plain",
+      },
+      value: "hello world",
+      decision: { status: "accept" },
+    });
+  });
+
+  it("reads binary files as byte arrays", async () => {
+    const file = new File([new Uint8Array([72, 73])], "hello.bin", {
+      type: "application/octet-stream",
+    });
+    const result = await readImportedFile(file, { as: "bytes" });
+
+    expect(result.ok).toBe(true);
+
+    if (!result.ok) {
+      throw new Error("expected byte read to succeed");
+    }
+
+    expect(result.file).toEqual({
+      name: "hello.bin",
+      size: 2,
+      type: "application/octet-stream",
+    });
+    expect(Array.from(result.value)).toEqual([72, 73]);
+  });
+
+  it("returns a typed oversize error before reading", async () => {
+    const file = new File(["12345"], "big.txt", { type: "text/plain" });
+    const result = await readImportedFile(file, {
+      as: "text",
+      policy: { maxBytes: 4 },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "file-too-large",
+        file: {
+          name: "big.txt",
+          size: 5,
+          type: "text/plain",
+        },
+        maxBytes: 4,
+      },
+    });
+  });
+
+  it("returns a typed read error when file reading fails", async () => {
+    const file = new File(["hello"], "broken.txt", { type: "text/plain" });
+    Object.defineProperty(file, "text", {
+      value: () => Promise.reject(new Error("disk offline")),
+    });
+
+    const result = await readImportedFile(file, { as: "text" });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "read-failed",
+        file: {
+          name: "broken.txt",
+          size: 5,
+          type: "text/plain",
+        },
+        message: "disk offline",
+      },
+    });
+  });
+
+  it("formats byte sizes for UI copy", () => {
+    expect(formatBytes(999)).toBe("999 B");
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(1572864)).toBe("1.5 MB");
+  });
+});

--- a/src/lib/fileImport.ts
+++ b/src/lib/fileImport.ts
@@ -1,0 +1,148 @@
+export const DEFAULT_IMPORT_WARN_BYTES = 512 * 1024;
+export const DEFAULT_IMPORT_MAX_BYTES = 2 * 1024 * 1024;
+
+export type FileImportReadMode = "text" | "bytes";
+
+export interface ImportedFileMeta {
+  name: string;
+  size: number;
+  type: string;
+}
+
+export interface FileImportPolicy {
+  warnBytes?: number;
+  maxBytes?: number;
+}
+
+export type FileImportError =
+  | {
+      code: "file-too-large";
+      file: ImportedFileMeta;
+      maxBytes: number;
+    }
+  | {
+      code: "read-failed";
+      file: ImportedFileMeta;
+      message: string;
+    };
+
+export type FileImportDecision =
+  | {
+      status: "accept";
+    }
+  | {
+      status: "warn";
+      warnBytes: number;
+    }
+  | {
+      status: "reject";
+      maxBytes: number;
+    };
+
+export type FileImportResult<T> =
+  | {
+      ok: true;
+      file: ImportedFileMeta;
+      value: T;
+      decision: FileImportDecision;
+    }
+  | {
+      ok: false;
+      error: FileImportError;
+    };
+
+function getFileMeta(file: File): ImportedFileMeta {
+  return {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+  };
+}
+
+export function evaluateFileImportPolicy(
+  file: Pick<File, "size">,
+  policy: FileImportPolicy = {}
+): FileImportDecision {
+  const warnBytes = policy.warnBytes ?? DEFAULT_IMPORT_WARN_BYTES;
+  const maxBytes = policy.maxBytes ?? DEFAULT_IMPORT_MAX_BYTES;
+
+  if (file.size > maxBytes) {
+    return {
+      status: "reject",
+      maxBytes,
+    };
+  }
+
+  if (file.size > warnBytes) {
+    return {
+      status: "warn",
+      warnBytes,
+    };
+  }
+
+  return {
+    status: "accept",
+  };
+}
+
+export async function readImportedFile(
+  file: File,
+  options: { as: "text"; policy?: FileImportPolicy }
+): Promise<FileImportResult<string>>;
+export async function readImportedFile(
+  file: File,
+  options: { as: "bytes"; policy?: FileImportPolicy }
+): Promise<FileImportResult<Uint8Array>>;
+export async function readImportedFile(
+  file: File,
+  options: { as: FileImportReadMode; policy?: FileImportPolicy }
+): Promise<FileImportResult<string | Uint8Array>> {
+  const fileMeta = getFileMeta(file);
+  const decision = evaluateFileImportPolicy(file, options.policy);
+
+  if (decision.status === "reject") {
+    return {
+      ok: false,
+      error: {
+        code: "file-too-large",
+        file: fileMeta,
+        maxBytes: decision.maxBytes,
+      },
+    };
+  }
+
+  try {
+    const value =
+      options.as === "text" ? await file.text() : new Uint8Array(await file.arrayBuffer());
+
+    return {
+      ok: true,
+      file: fileMeta,
+      value,
+      decision,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "read-failed",
+        file: fileMeta,
+        message: error instanceof Error ? error.message : "Failed to read file",
+      },
+    };
+  }
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const kilobytes = bytes / 1024;
+  if (kilobytes < 1024) {
+    return `${Math.round(kilobytes)} KB`;
+  }
+
+  const megabytes = kilobytes / 1024;
+  return `${megabytes.toFixed(megabytes >= 10 ? 0 : 1)} MB`;
+}

--- a/src/tools/base64/Base64Tool.tsx
+++ b/src/tools/base64/Base64Tool.tsx
@@ -1,6 +1,12 @@
 import { createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
+import {
+  DEFAULT_IMPORT_MAX_BYTES,
+  type FileImportError,
+  formatBytes,
+  readImportedFile,
+} from "@/lib/fileImport";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,6 +38,14 @@ interface Result {
   error: string | null;
 }
 
+function encodeBytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
 function process(input: string, mode: Mode): Result {
   const trimmed = input.trim();
   if (!trimmed) return { value: "", error: null };
@@ -59,44 +73,61 @@ function process(input: string, mode: Mode): Result {
 export default function Base64Tool() {
   const [mode, setMode] = createSignal<Mode>("encode");
   const [input, setInput] = createSignal("");
+  const [fileError, setFileError] = createSignal<FileImportError | null>(null);
+  const [fileNotice, setFileNotice] = createSignal<string | null>(null);
 
   const result = (): Result => process(input(), mode());
 
   function swap() {
     const current = result().value;
+    setFileError(null);
+    setFileNotice(null);
     setMode((m) => (m === "encode" ? "decode" : "encode"));
     setInput(current);
   }
 
-  function handleFile(file: File) {
-    if (file.size > 2 * 1024 * 1024) {
-      setInput(""); // clear input and let error show via the signal
-      // We need to signal the oversize case separately
-      setInput("__FILE_TOO_LARGE__");
+  async function handleFile(file: File) {
+    setFileError(null);
+    setFileNotice(null);
+
+    if (mode() === "encode") {
+      const result = await readImportedFile(file, {
+        as: "bytes",
+        policy: { maxBytes: DEFAULT_IMPORT_MAX_BYTES },
+      });
+
+      if (!result.ok) {
+        setFileError(result.error);
+        return;
+      }
+
+      if (result.decision.status === "warn") {
+        setFileNotice(
+          `${file.name} is ${formatBytes(result.file.size)}. Large files may take longer to encode.`
+        );
+      }
+
+      setInput(encodeBytesToBase64(result.value));
       return;
     }
-    const reader = new FileReader();
-    if (mode() === "encode") {
-      reader.onload = () => {
-        const arr = new Uint8Array(reader.result as ArrayBuffer);
-        let binary = "";
-        for (let i = 0; i < arr.length; i++) {
-          binary += String.fromCharCode(arr[i]);
-        }
-        setInput(btoa(binary));
-        // Switch to decode mode after reading so user sees the base64 output
-        setMode("decode");
-        // Actually keep in encode mode — file -> show base64
-        setMode("encode");
-        setInput(btoa(binary));
-      };
-      reader.readAsArrayBuffer(file);
-    } else {
-      reader.onload = () => {
-        setInput(reader.result as string);
-      };
-      reader.readAsText(file);
+
+    const result = await readImportedFile(file, {
+      as: "text",
+      policy: { maxBytes: DEFAULT_IMPORT_MAX_BYTES },
+    });
+
+    if (!result.ok) {
+      setFileError(result.error);
+      return;
     }
+
+    if (result.decision.status === "warn") {
+      setFileNotice(
+        `${file.name} is ${formatBytes(result.file.size)}. Large files may take longer to decode.`
+      );
+    }
+
+    setInput(result.value);
   }
 
   function onDrop(e: DragEvent) {
@@ -104,6 +135,15 @@ export default function Base64Tool() {
     const file = e.dataTransfer?.files?.[0];
     if (file) handleFile(file);
   }
+
+  const fileReadErrorMessage = () => {
+    const error = fileError();
+    if (!error || error.code !== "read-failed") {
+      return null;
+    }
+
+    return `${error.file.name} could not be read. ${error.message}.`;
+  };
 
   const tabStyle = (active: boolean) => ({
     padding: "0.375rem 1rem",
@@ -199,8 +239,12 @@ export default function Base64Tool() {
           style={{ position: "relative" }}
         >
           <textarea
-            value={input() === "__FILE_TOO_LARGE__" ? "" : input()}
-            onInput={(e) => setInput(e.currentTarget.value)}
+            value={input()}
+            onInput={(e) => {
+              setFileError(null);
+              setFileNotice(null);
+              setInput(e.currentTarget.value);
+            }}
             placeholder={
               mode() === "encode"
                 ? "Type or paste text to encode, or drop a file…"
@@ -245,14 +289,30 @@ export default function Base64Tool() {
               }}
             />
           </label>
-          <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>· max 2 MB</span>
+          <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>
+            · max {formatBytes(DEFAULT_IMPORT_MAX_BYTES)}
+          </span>
         </div>
       </div>
 
       {/* ------------------------------------------------------------------ */}
       {/* Error banner                                                        */}
       {/* ------------------------------------------------------------------ */}
-      <Show when={input() === "__FILE_TOO_LARGE__"}>
+      <Show when={fileNotice()}>
+        <div
+          style={{
+            padding: "0.75rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid color-mix(in srgb, var(--accent-warning) 60%, transparent)",
+            background: "color-mix(in srgb, var(--accent-warning) 12%, transparent)",
+            color: "var(--accent-warning)",
+            "font-size": "0.875rem",
+          }}
+        >
+          {fileNotice()}
+        </div>
+      </Show>
+      <Show when={fileError()?.code === "file-too-large"}>
         <div
           role="alert"
           style={{
@@ -264,7 +324,22 @@ export default function Base64Tool() {
             "font-size": "0.875rem",
           }}
         >
-          File is too large — maximum supported size is 2 MB.
+          File is too large — maximum supported size is {formatBytes(DEFAULT_IMPORT_MAX_BYTES)}.
+        </div>
+      </Show>
+      <Show when={fileError()?.code === "read-failed"}>
+        <div
+          role="alert"
+          style={{
+            padding: "0.75rem 1rem",
+            "border-radius": "0.5rem",
+            border: "1px solid var(--accent-error)",
+            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
+            color: "var(--accent-error)",
+            "font-size": "0.875rem",
+          }}
+        >
+          {fileReadErrorMessage()}
         </div>
       </Show>
       <Show when={result().error}>

--- a/src/tools/diff/DiffTool.tsx
+++ b/src/tools/diff/DiffTool.tsx
@@ -6,6 +6,7 @@ import {
   getChangeSourceIndices,
   getDiffStats,
 } from "@/lib/diff";
+import { DEFAULT_IMPORT_MAX_BYTES, formatBytes, readImportedFile } from "@/lib/fileImport";
 import { type Language, SUPPORTED_LANGUAGES } from "@/lib/language";
 import { detectLanguage } from "@/lib/languageDetection";
 import { prepareStructuredCompare } from "@/lib/structuredCompare";
@@ -36,19 +37,6 @@ const STRATEGY_LABELS: Record<string, string> = {
   env: "Normalized .env",
   text: "Text",
 };
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function readFileAsText(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (e) => resolve((e.target?.result as string) ?? "");
-    reader.onerror = () => reject(new Error("Failed to read file"));
-    reader.readAsText(file);
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -260,6 +248,8 @@ export default function DiffTool() {
   const [changesOnly, setChangesOnly] = createSignal(true);
   const [pending, setPending] = createSignal(false);
   const [currentChangeIdx, setCurrentChangeIdx] = createSignal(0);
+  const [fileError, setFileError] = createSignal<string | null>(null);
+  const [fileNotice, setFileNotice] = createSignal<string | null>(null);
 
   // diffData holds the committed snapshot used for computing the diff
   const [diffData, setDiffData] = createSignal<{
@@ -337,16 +327,37 @@ export default function DiffTool() {
 
   // --- File handling --------------------------------------------------------
   async function handleFileLoad(side: "left" | "right", file: File) {
-    const text = await readFileAsText(file);
-    const lang = detectLanguage({ filename: file.name, content: text });
+    setFileError(null);
+    setFileNotice(null);
+
+    const result = await readImportedFile(file, { as: "text" });
+
+    if (!result.ok) {
+      if (result.error.code === "file-too-large") {
+        setFileError(
+          `${file.name} is too large to open here. Maximum supported size is ${formatBytes(result.error.maxBytes)}.`
+        );
+      } else {
+        setFileError(`${file.name} could not be read. ${result.error.message}.`);
+      }
+      return;
+    }
+
+    if (result.decision.status === "warn") {
+      setFileNotice(
+        `${file.name} is ${formatBytes(result.file.size)}. Large files may take longer to compare.`
+      );
+    }
+
+    const lang = detectLanguage({ filename: file.name, content: result.value });
     if (side === "left") {
       batch(() => {
-        setLeftContent(text);
+        setLeftContent(result.value);
         setLeftLang(lang);
       });
     } else {
       batch(() => {
-        setRightContent(text);
+        setRightContent(result.value);
         setRightLang(lang);
       });
     }
@@ -481,6 +492,37 @@ export default function DiffTool() {
           }}
         >
           Paste two texts to compare, or open files with the buttons above.
+        </div>
+      </Show>
+
+      <Show when={fileError()}>
+        <div
+          role="alert"
+          style={{
+            padding: "0.6rem 0.875rem",
+            "border-radius": "0.375rem",
+            border: "1px solid var(--accent-error)",
+            background: "color-mix(in srgb, var(--accent-error) 10%, transparent)",
+            color: "var(--accent-error)",
+            "font-size": "0.8125rem",
+          }}
+        >
+          {fileError()}
+        </div>
+      </Show>
+
+      <Show when={fileNotice()}>
+        <div
+          style={{
+            padding: "0.6rem 0.875rem",
+            "border-radius": "0.375rem",
+            border: "1px solid color-mix(in srgb, var(--accent-warning) 60%, transparent)",
+            background: "color-mix(in srgb, var(--accent-warning) 10%, transparent)",
+            color: "var(--accent-warning)",
+            "font-size": "0.8125rem",
+          }}
+        >
+          {fileNotice()}
         </div>
       </Show>
 
@@ -626,6 +668,15 @@ export default function DiffTool() {
           >
             ⇅ Swap
           </button>
+
+          <span
+            style={{
+              "font-size": "0.75rem",
+              color: "var(--text-muted)",
+            }}
+          >
+            File limit {formatBytes(DEFAULT_IMPORT_MAX_BYTES)}
+          </span>
         </div>
 
         {/* ------------------------------------------------------------------ */}


### PR DESCRIPTION
## Summary
- add a shared local file import service with consistent size policy decisions, typed errors, and reusable byte-size formatting
- migrate the Diff and Base64 tools to the shared importer so selected and dropped files report large-file warnings and explicit import failures consistently
- add focused tests for policy outcomes, text and byte reads, oversize rejection, read failures, and UI-facing byte formatting

## Verification
- `bun run type-check`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run format:check`

## Preview Testing
- Open the Vercel preview deployment from this PR once checks finish.
- Visit `/tools/base64`.
- In `Encode` mode, drop or open a small binary file and confirm the input fills with Base64 output.
- In `Decode` mode, drop or open a text file that contains Base64 and confirm the decoded plain-text output renders below.
- In `/tools/base64`, try a file a little over `512 KB` and confirm a non-blocking large-file warning appears.
- In `/tools/base64`, try a file over `2 MB` and confirm the tool blocks the import with a size error.
- Visit `/tools/diff`.
- Open two small text files and confirm both panes load, language detection still updates, and the diff renders normally.
- In `/tools/diff`, try a file a little over `512 KB` and confirm a non-blocking large-file warning appears.
- In `/tools/diff`, try a file over `2 MB` and confirm the tool blocks the import with a clear error.

## Closes
- Closes #54
- Closes #27