### PR TITLE
refactor(platform): make tool registry executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 dist/
 .output/
+.astro-test-dist/
 
 # Astro
 .astro/

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -53,6 +53,6 @@ export default [
 
   // Ignore patterns
   {
-    ignores: ["dist/", ".astro/", "node_modules/"],
+    ignores: ["dist/", ".astro/", ".astro-test-dist/", "node_modules/"],
   },
 ];

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -14,7 +14,7 @@ import { createEffect, createSignal, For, onCleanup, onMount, Show } from "solid
 import type { JSX } from "solid-js";
 
 import { searchTools } from "@/lib/search";
-import { type Tool, tools } from "@/tools/registry";
+import { getToolRoute, type Tool, tools } from "@/tools/registry";
 
 // Map of lucide icon name → component
 const ICON_MAP: Record<string, (props: { size?: number; class?: string }) => JSX.Element> = {
@@ -71,7 +71,7 @@ export default function CommandPalette() {
 
   function navigateTo(slug: string) {
     closePalette();
-    window.location.href = `/tools/${slug}`;
+    window.location.href = getToolRoute(slug);
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -1,4 +1,5 @@
 ---
+import { getToolRoute } from "@/tools/registry";
 import type { Tool } from "@/tools/registry";
 
 interface Props {
@@ -22,7 +23,7 @@ const badgeClass =
 ---
 
 <a
-  href={`/tools/${tool.slug}`}
+  href={getToolRoute(tool.slug)}
   class="group relative flex flex-col gap-4 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] p-5 transition-colors duration-150 hover:border-[var(--accent-primary)] hover:bg-[var(--bg-tertiary)]"
 >
   {/* Icon area — icon component will be added in a later phase */}

--- a/src/components/ToolHost.tsx
+++ b/src/components/ToolHost.tsx
@@ -1,0 +1,35 @@
+import type { Component } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
+import { Dynamic, isServer } from "solid-js/web";
+
+interface ToolHostProps {
+  componentPath: string;
+}
+
+const toolModules = import.meta.glob<{ default: Component }>("../tools/*/*.tsx");
+
+export default function ToolHost(props: ToolHostProps) {
+  const [toolComponent, setToolComponent] = createSignal<Component | null>(null);
+
+  onMount(async () => {
+    try {
+      const modulePath = `../${props.componentPath.slice(5)}`;
+      const loadTool = toolModules[modulePath];
+
+      if (!loadTool) {
+        throw new Error(`Missing tool component loader for ${props.componentPath}`);
+      }
+
+      const module = await loadTool();
+      setToolComponent(() => module.default);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+  if (isServer) {
+    return null;
+  }
+
+  return <Show when={toolComponent()}>{(Component) => <Dynamic component={Component()} />}</Show>;
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,3 @@
+/// <reference types="vite/client" />
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../.astro/types.d.ts" />

--- a/src/layouts/EditorShell.astro
+++ b/src/layouts/EditorShell.astro
@@ -4,7 +4,7 @@ import { ViewTransitions } from "astro:transitions";
 import CommandPalette from "@/components/CommandPalette";
 import SettingsModal from "@/components/SettingsModal";
 import "@/styles/global.css";
-import { tools } from "@/tools/registry";
+import { getToolRoute, tools } from "@/tools/registry";
 import type { ToolCategory } from "@/tools/registry";
 
 interface Props {
@@ -157,7 +157,7 @@ const grouped: GroupedTool[] = categoryOrder
                   {group.items.map((tool) => (
                     <li>
                       <a
-                        href={`/tools/${tool.slug}`}
+                        href={getToolRoute(tool.slug)}
                         class:list={[
                           "sidebar-item",
                           { "sidebar-item--active": tool.slug === activeSlug },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import EditorShell from "@/layouts/EditorShell.astro";
-import { tools } from "@/tools/registry";
+import { getToolRoute, tools } from "@/tools/registry";
 import type { ToolCategory } from "@/tools/registry";
 
 const catColor: Record<ToolCategory, string> = {
@@ -33,7 +33,7 @@ function toCamelCase(slug: string): string {
 <!-- line 5 -->&nbsp;
 <!-- line 6 --><span class="tok-kw">const</span> <span class="tok-id">tools</span> <span class="tok-punct">=</span> <span class="tok-punct">{"{"}</span>
 {tools.map((tool) => (
-<a href={`/tools/${tool.slug}`} class="code-line-link">  <span class="tok-id">{toCamelCase(tool.slug)}</span><span class="tok-punct">:</span> <span class="tok-punct">{"{"}</span> <span class="tok-cat" style={`color: ${catColor[tool.category]}`}>[{tool.category}]</span> <span class="tok-str">"{tool.name}"</span> <span class="tok-punct">{"}"}</span><span class="tok-punct">,</span>
+<a href={getToolRoute(tool.slug)} class="code-line-link">  <span class="tok-id">{toCamelCase(tool.slug)}</span><span class="tok-punct">:</span> <span class="tok-punct">{"{"}</span> <span class="tok-cat" style={`color: ${catColor[tool.category]}`}>[{tool.category}]</span> <span class="tok-str">"{tool.name}"</span> <span class="tok-punct">{"}"}</span><span class="tok-punct">,</span>
 </a>
 ))}<span class="tok-punct">{"}"}</span><span class="tok-punct">;</span>
 &nbsp;
@@ -46,7 +46,7 @@ function toCamelCase(slug: string): string {
       </div>
       {
         tools.map((tool) => (
-          <a href={`/tools/${tool.slug}`} class="tool-ref-row">
+          <a href={getToolRoute(tool.slug)} class="tool-ref-row">
             <span class="tool-ref-cat" style={`color: ${catColor[tool.category]}`}>
               [{tool.category}]
             </span>

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -1,14 +1,19 @@
 ---
+import ToolHost from "@/components/ToolHost";
 import EditorShell from "@/layouts/EditorShell.astro";
-import Base64Tool from "@/tools/base64/Base64Tool";
-import DiffTool from "@/tools/diff/DiffTool";
-import HashGenerator from "@/tools/hash-generator/HashGenerator";
-import JsonFormatter from "@/tools/json-formatter/JsonFormatter";
-import JwtDecoder from "@/tools/jwt-decoder/JwtDecoder";
-import RegexTester from "@/tools/regex-tester/RegexTester";
-import TimestampTool from "@/tools/timestamp/TimestampTool";
-import UuidGenerator from "@/tools/uuid-generator/UuidGenerator";
-import { getToolBySlug, tools } from "@/tools/registry";
+import { getToolBySlug, tools, validateToolRegistry } from "@/tools/registry";
+
+const toolModules = import.meta.glob("../../tools/*/*.tsx");
+
+const availableToolComponentPaths = Object.keys(toolModules).map((path) =>
+  path.startsWith("../../") ? `/src/${path.slice(6)}` : path
+);
+
+const registryErrors = validateToolRegistry(availableToolComponentPaths);
+
+if (registryErrors.length > 0) {
+  throw new Error(`Invalid tool registry:\n${registryErrors.join("\n")}`);
+}
 
 export function getStaticPaths() {
   return tools.map((tool) => ({
@@ -37,33 +42,7 @@ if (!tool) {
 
     <!-- Tool component -->
     <div class="tool-body">
-      {
-        slug === "jwt-decoder" ? (
-          <JwtDecoder client:load />
-        ) : slug === "diff" ? (
-          <DiffTool client:load />
-        ) : slug === "base64" ? (
-          <Base64Tool client:load />
-        ) : slug === "json-formatter" ? (
-          <JsonFormatter client:load />
-        ) : slug === "hash-generator" ? (
-          <HashGenerator client:load />
-        ) : slug === "uuid-generator" ? (
-          <UuidGenerator client:load />
-        ) : slug === "timestamp" ? (
-          <TimestampTool client:load />
-        ) : slug === "regex-tester" ? (
-          <RegexTester client:load />
-        ) : (
-          <div class="tool-coming-soon">
-            <p class="tool-soon-name">{tool.name}</p>
-            <p>This tool is coming soon.</p>
-            <a href="/" class="tool-soon-link">
-              &larr; Back to all tools
-            </a>
-          </div>
-        )
-      }
+      <ToolHost componentPath={tool.componentPath} client:load />
     </div>
   </div>
 </EditorShell>
@@ -99,26 +78,6 @@ if (!tool) {
   .tool-body {
     flex: 1;
     padding: 1.5rem;
-  }
-
-  .tool-coming-soon {
-    padding: 2rem;
-    text-align: center;
-    color: var(--text-muted);
-  }
-
-  .tool-soon-name {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin-bottom: 0.5rem;
-  }
-
-  .tool-soon-link {
-    color: var(--accent-primary);
-    text-decoration: none;
-    margin-top: 1rem;
-    display: inline-block;
   }
 
   @media (max-width: 600px) {

--- a/src/test/routes.smoke.test.ts
+++ b/src/test/routes.smoke.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { getToolRoute, tools } from "../tools/registry";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, "../..");
+const distDir = resolve(repoRoot, ".astro-test-dist");
+
+function readBuiltHtml(filePath: string): string {
+  const absolutePath = resolve(distDir, filePath);
+  expect(existsSync(absolutePath)).toBe(true);
+  return readFileSync(absolutePath, "utf8");
+}
+
+beforeAll(() => {
+  rmSync(distDir, { force: true, recursive: true });
+
+  execFileSync("bunx", ["astro", "build", "--outDir", distDir], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+}, 30000);
+
+describe("route smoke", () => {
+  it("builds the home route with links to every registered tool", () => {
+    const html = readBuiltHtml("index.html");
+
+    expect(html).toContain("unwrapped.tools");
+
+    for (const tool of tools) {
+      expect(html).toContain(getToolRoute(tool.slug));
+    }
+  });
+
+  for (const tool of tools) {
+    it(`builds ${getToolRoute(tool.slug)}`, () => {
+      const html = readBuiltHtml(`tools/${tool.slug}/index.html`);
+
+      expect(html).toContain(tool.name);
+      expect(html).toContain(tool.description);
+    });
+  }
+});

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { tools, validateToolRegistry } from "./registry";
+
+const toolComponentPaths = tools.map((tool) => tool.componentPath);
+
+describe("tool registry", () => {
+  it("has no duplicate ids, duplicate slugs, or missing component paths", () => {
+    expect(validateToolRegistry(toolComponentPaths)).toEqual([]);
+  });
+
+  it("uses component paths that match the tool slug folders", () => {
+    for (const tool of tools) {
+      expect(tool.componentPath).toBe(
+        `/src/tools/${tool.slug}/${tool.componentPath.split("/").at(-1)}`
+      );
+    }
+  });
+});

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -15,6 +15,7 @@ export interface Tool {
   keywords: string[];
   icon: string; // lucide icon name
   slug: string; // matches folder name, used in URL
+  componentPath: string;
   isNew?: boolean;
 }
 
@@ -27,6 +28,7 @@ export const tools: Tool[] = [
     keywords: ["jwt", "token", "bearer", "auth", "decode", "json web token"],
     icon: "KeyRound",
     slug: "jwt-decoder",
+    componentPath: "/src/tools/jwt-decoder/JwtDecoder.tsx",
   },
   {
     id: "diff",
@@ -36,6 +38,7 @@ export const tools: Tool[] = [
     keywords: ["diff", "compare", "config", "delta", "difference", "text"],
     icon: "GitCompare",
     slug: "diff",
+    componentPath: "/src/tools/diff/DiffTool.tsx",
   },
   {
     id: "base64",
@@ -45,6 +48,7 @@ export const tools: Tool[] = [
     keywords: ["base64", "encode", "decode", "binary", "btoa", "atob"],
     icon: "Binary",
     slug: "base64",
+    componentPath: "/src/tools/base64/Base64Tool.tsx",
   },
   {
     id: "json-formatter",
@@ -54,6 +58,7 @@ export const tools: Tool[] = [
     keywords: ["json", "format", "prettify", "minify", "validate", "lint"],
     icon: "Braces",
     slug: "json-formatter",
+    componentPath: "/src/tools/json-formatter/JsonFormatter.tsx",
   },
   {
     id: "hash-generator",
@@ -63,6 +68,7 @@ export const tools: Tool[] = [
     keywords: ["hash", "sha", "sha256", "sha512", "checksum", "digest", "crypto"],
     icon: "Fingerprint",
     slug: "hash-generator",
+    componentPath: "/src/tools/hash-generator/HashGenerator.tsx",
   },
   {
     id: "uuid-generator",
@@ -72,6 +78,7 @@ export const tools: Tool[] = [
     keywords: ["uuid", "guid", "unique", "id", "random", "generate"],
     icon: "Shuffle",
     slug: "uuid-generator",
+    componentPath: "/src/tools/uuid-generator/UuidGenerator.tsx",
   },
   {
     id: "timestamp",
@@ -81,6 +88,7 @@ export const tools: Tool[] = [
     keywords: ["timestamp", "unix", "epoch", "date", "time", "convert", "utc"],
     icon: "Clock",
     slug: "timestamp",
+    componentPath: "/src/tools/timestamp/TimestampTool.tsx",
   },
   {
     id: "regex-tester",
@@ -90,8 +98,42 @@ export const tools: Tool[] = [
     keywords: ["regex", "regexp", "regular expression", "pattern", "match", "test"],
     icon: "Regex",
     slug: "regex-tester",
+    componentPath: "/src/tools/regex-tester/RegexTester.tsx",
   },
 ];
+
+export function getToolRoute(slug: string): `/tools/${string}` {
+  return `/tools/${slug}`;
+}
+
+export function validateToolRegistry(availableComponentPaths: readonly string[] = []): string[] {
+  const errors: string[] = [];
+  const seenIds = new Set<string>();
+  const seenSlugs = new Set<string>();
+
+  for (const tool of tools) {
+    if (seenIds.has(tool.id)) {
+      errors.push(`Duplicate tool id: ${tool.id}`);
+    } else {
+      seenIds.add(tool.id);
+    }
+
+    if (seenSlugs.has(tool.slug)) {
+      errors.push(`Duplicate tool slug: ${tool.slug}`);
+    } else {
+      seenSlugs.add(tool.slug);
+    }
+
+    if (
+      availableComponentPaths.length > 0 &&
+      !availableComponentPaths.includes(tool.componentPath)
+    ) {
+      errors.push(`Missing tool component: ${tool.componentPath}`);
+    }
+  }
+
+  return errors;
+}
 
 export function getToolBySlug(slug: string): Tool | undefined {
   return tools.find((t) => t.slug === slug);


### PR DESCRIPTION
## Summary
- move tool route execution onto the registry by storing each tool's component path and validating registry/component wiring during route generation
- replace hand-maintained `/tools/[slug]` rendering branches with a shared `ToolHost` so registered tools resolve through one contract
- add registry invariant tests and route smoke coverage that build the home page and every registered tool route from the same registry data

## Closes
- Closes #52
- Closes #56

## Verification
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run format:check`

## Preview Testing
- Open the Vercel preview deployment from this PR once checks finish.
- Visit `/` and confirm every tool listed on the homepage still opens the correct route.
- Open the command palette with `Cmd+K` or `Ctrl+K` and confirm selecting several tools navigates to the correct pages.
- Visit `/tools/diff`, `/tools/base64`, and `/tools/regex-tester` and confirm each page still renders its tool after hydration.
- Confirm the sidebar links still navigate correctly between tools and the active tool remains highlighted.
- If you want a quick drift check, compare the set of tools shown on `/` with the routes available under `/tools/*` in the preview and confirm nothing is missing.