### PR TITLE
feat(platform): persist diff sessions locally

### DIFF
--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { clearSessionState, loadSessionState, saveSessionState } from "./session";
+
+function createStorage() {
+  const values = new Map<string, string>();
+
+  return {
+    values,
+    storage: {
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        values.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        values.delete(key);
+      }),
+    },
+  };
+}
+
+describe("session utilities", () => {
+  it("loads validated versioned session data", () => {
+    const { storage, values } = createStorage();
+    values.set("demo", JSON.stringify({ version: 1, data: { value: "ok" } }));
+
+    const result = loadSessionState({
+      key: "demo",
+      version: 1,
+      storage,
+      isData: (value): value is { value: string } => {
+        if (typeof value !== "object" || value === null) {
+          return false;
+        }
+
+        const parsed = value as Record<string, unknown>;
+        return typeof parsed.value === "string";
+      },
+    });
+
+    expect(result).toEqual({ value: "ok" });
+  });
+
+  it("returns null for malformed or invalid session data", () => {
+    const { storage, values } = createStorage();
+    values.set("broken", "not-json");
+
+    const result = loadSessionState({
+      key: "broken",
+      version: 1,
+      storage,
+      isData: (_value): _value is { value: string } => true,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("saves and clears versioned session data", () => {
+    const { storage, values } = createStorage();
+
+    saveSessionState({
+      key: "demo",
+      version: 2,
+      storage,
+      data: { value: "saved" },
+    });
+
+    expect(values.get("demo")).toBe(JSON.stringify({ version: 2, data: { value: "saved" } }));
+
+    clearSessionState("demo", storage);
+
+    expect(values.has("demo")).toBe(false);
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,73 @@
+export interface PersistedSessionEnvelope<T> {
+  version: number;
+  data: T;
+}
+
+export interface SessionOptions<T> {
+  key: string;
+  version: number;
+  isData: (value: unknown) => value is T;
+  migrate?: (value: unknown, fromVersion: number) => T | null;
+  storage?: Pick<Storage, "getItem" | "setItem" | "removeItem"> | null;
+}
+
+export function getBrowserStorage(): Storage | null {
+  return typeof localStorage === "undefined" ? null : localStorage;
+}
+
+export function loadSessionState<T>(options: SessionOptions<T>): T | null {
+  const storage = options.storage ?? getBrowserStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(options.key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<PersistedSessionEnvelope<unknown>>;
+    if (typeof parsed !== "object" || parsed === null || typeof parsed.version !== "number") {
+      return null;
+    }
+
+    if (parsed.version === options.version) {
+      return options.isData(parsed.data) ? parsed.data : null;
+    }
+
+    if (!options.migrate) {
+      return null;
+    }
+
+    return options.migrate(parsed.data, parsed.version);
+  } catch {
+    return null;
+  }
+}
+
+export function saveSessionState<T>(
+  options: Pick<SessionOptions<T>, "key" | "version" | "storage"> & { data: T }
+): void {
+  const storage = options.storage ?? getBrowserStorage();
+  if (!storage) return;
+
+  try {
+    const payload: PersistedSessionEnvelope<T> = {
+      version: options.version,
+      data: options.data,
+    };
+    storage.setItem(options.key, JSON.stringify(payload));
+  } catch {
+    // Ignore quota and storage access failures.
+  }
+}
+
+export function clearSessionState(
+  key: string,
+  storage: Pick<Storage, "removeItem"> | null = getBrowserStorage()
+): void {
+  if (!storage) return;
+
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Ignore storage access failures.
+  }
+}

--- a/src/tools/diff/DiffTool.tsx
+++ b/src/tools/diff/DiffTool.tsx
@@ -1,4 +1,13 @@
-import { batch, createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import {
+  batch,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
 
 import {
   createDiffRows,
@@ -9,7 +18,15 @@ import {
 import { DEFAULT_IMPORT_MAX_BYTES, formatBytes, readImportedFile } from "@/lib/fileImport";
 import { type Language, SUPPORTED_LANGUAGES } from "@/lib/language";
 import { detectLanguage } from "@/lib/languageDetection";
+import { clearSessionState, loadSessionState, saveSessionState } from "@/lib/session";
 import { prepareStructuredCompare } from "@/lib/structuredCompare";
+import {
+  DIFF_SESSION_STORAGE_KEY,
+  DIFF_SESSION_VERSION,
+  type DiffFileMeta,
+  isDiffSessionState,
+  shouldPersistDiffSession,
+} from "@/tools/diff/diffSession";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -46,6 +63,7 @@ interface InputPanelProps {
   label: string;
   content: string;
   lang: Language;
+  fileMeta: DiffFileMeta | null;
   onContentChange: (v: string) => void;
   onLangChange: (v: Language) => void;
   fileInputRef: (el: HTMLInputElement) => void;
@@ -206,6 +224,26 @@ function InputPanel(props: InputPanelProps) {
           />
         </div>
 
+        <Show when={props.fileMeta}>
+          {(fileMeta) => (
+            <div
+              style={{
+                display: "flex",
+                gap: "0.5rem",
+                padding: "0.35rem 0.75rem",
+                "border-bottom": "1px solid var(--border)",
+                background: "color-mix(in srgb, var(--bg-tertiary) 70%, transparent)",
+                color: "var(--text-muted)",
+                "font-size": "0.75rem",
+                "font-family": "var(--font-mono)",
+              }}
+            >
+              <span>{fileMeta().name}</span>
+              <span>{formatBytes(fileMeta().size)}</span>
+            </div>
+          )}
+        </Show>
+
         {/* Textarea */}
         <textarea
           value={props.content}
@@ -250,6 +288,8 @@ export default function DiffTool() {
   const [currentChangeIdx, setCurrentChangeIdx] = createSignal(0);
   const [fileError, setFileError] = createSignal<string | null>(null);
   const [fileNotice, setFileNotice] = createSignal<string | null>(null);
+  const [leftFile, setLeftFile] = createSignal<DiffFileMeta | null>(null);
+  const [rightFile, setRightFile] = createSignal<DiffFileMeta | null>(null);
 
   // diffData holds the committed snapshot used for computing the diff
   const [diffData, setDiffData] = createSignal<{
@@ -261,6 +301,28 @@ export default function DiffTool() {
 
   // --- Debounced diff trigger -----------------------------------------------
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onMount(() => {
+    const savedSession = loadSessionState({
+      key: DIFF_SESSION_STORAGE_KEY,
+      version: DIFF_SESSION_VERSION,
+      isData: isDiffSessionState,
+    });
+
+    if (!savedSession) {
+      return;
+    }
+
+    batch(() => {
+      setLeftContent(savedSession.leftContent);
+      setRightContent(savedSession.rightContent);
+      setLeftLang(savedSession.leftLang);
+      setRightLang(savedSession.rightLang);
+      setChangesOnly(savedSession.changesOnly);
+      setLeftFile(savedSession.leftFile);
+      setRightFile(savedSession.rightFile);
+    });
+  });
 
   createEffect(() => {
     // Access reactive dependencies
@@ -285,6 +347,39 @@ export default function DiffTool() {
         setCurrentChangeIdx(0);
       });
     }, DEBOUNCE_MS);
+  });
+
+  createEffect(() => {
+    const sessionState = {
+      leftContent: leftContent(),
+      rightContent: rightContent(),
+      leftLang: leftLang(),
+      rightLang: rightLang(),
+      changesOnly: changesOnly(),
+      leftFile: leftFile(),
+      rightFile: rightFile(),
+    };
+
+    if (
+      sessionState.leftContent === "" &&
+      sessionState.rightContent === "" &&
+      sessionState.leftFile === null &&
+      sessionState.rightFile === null
+    ) {
+      clearSessionState(DIFF_SESSION_STORAGE_KEY);
+      return;
+    }
+
+    if (!shouldPersistDiffSession(sessionState)) {
+      clearSessionState(DIFF_SESSION_STORAGE_KEY);
+      return;
+    }
+
+    saveSessionState({
+      key: DIFF_SESSION_STORAGE_KEY,
+      version: DIFF_SESSION_VERSION,
+      data: sessionState,
+    });
   });
 
   onCleanup(() => {
@@ -354,11 +449,13 @@ export default function DiffTool() {
       batch(() => {
         setLeftContent(result.value);
         setLeftLang(lang);
+        setLeftFile(result.file);
       });
     } else {
       batch(() => {
         setRightContent(result.value);
         setRightLang(lang);
+        setRightFile(result.file);
       });
     }
   }
@@ -387,10 +484,14 @@ export default function DiffTool() {
       const rc = rightContent();
       const ll = leftLang();
       const rl = rightLang();
+      const lf = leftFile();
+      const rf = rightFile();
       setLeftContent(rc);
       setRightContent(lc);
       setLeftLang(rl);
       setRightLang(ll);
+      setLeftFile(rf);
+      setRightFile(lf);
     });
   }
 
@@ -463,6 +564,7 @@ export default function DiffTool() {
           label="Original"
           content={leftContent()}
           lang={leftLang()}
+          fileMeta={leftFile()}
           onContentChange={setLeftContent}
           onLangChange={setLeftLang}
           fileInputRef={(_el) => {}}
@@ -472,6 +574,7 @@ export default function DiffTool() {
           label="Modified"
           content={rightContent()}
           lang={rightLang()}
+          fileMeta={rightFile()}
           onContentChange={setRightContent}
           onLangChange={setRightLang}
           fileInputRef={(_el) => {}}

--- a/src/tools/diff/diffSession.test.ts
+++ b/src/tools/diff/diffSession.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { isDiffSessionState, shouldPersistDiffSession } from "./diffSession";
+
+describe("diff session schema", () => {
+  it("accepts valid diff session state", () => {
+    expect(
+      isDiffSessionState({
+        leftContent: "a",
+        rightContent: "b",
+        leftLang: "json",
+        rightLang: "yaml",
+        changesOnly: true,
+        leftFile: { name: "left.json", size: 10, type: "application/json" },
+        rightFile: null,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects invalid diff session state", () => {
+    expect(
+      isDiffSessionState({
+        leftContent: "a",
+        rightContent: "b",
+        leftLang: "toml",
+        rightLang: "yaml",
+        changesOnly: true,
+        leftFile: null,
+        rightFile: null,
+      })
+    ).toBe(false);
+  });
+
+  it("caps persistence for overly large diff inputs", () => {
+    expect(
+      shouldPersistDiffSession({
+        leftContent: "a".repeat(50_000),
+        rightContent: "b".repeat(50_000),
+      })
+    ).toBe(true);
+    expect(
+      shouldPersistDiffSession({
+        leftContent: "a".repeat(50_001),
+        rightContent: "b".repeat(50_000),
+      })
+    ).toBe(false);
+  });
+});

--- a/src/tools/diff/diffSession.ts
+++ b/src/tools/diff/diffSession.ts
@@ -1,0 +1,61 @@
+import { type Language, SUPPORTED_LANGUAGES } from "../../lib/language";
+
+export const DIFF_SESSION_STORAGE_KEY = "unwrapped-tool-session:diff";
+export const DIFF_SESSION_VERSION = 1;
+export const DIFF_SESSION_MAX_CHARS = 100_000;
+
+export interface DiffFileMeta {
+  name: string;
+  size: number;
+  type: string;
+}
+
+export interface DiffSessionState {
+  leftContent: string;
+  rightContent: string;
+  leftLang: Language;
+  rightLang: Language;
+  changesOnly: boolean;
+  leftFile: DiffFileMeta | null;
+  rightFile: DiffFileMeta | null;
+}
+
+function isLanguage(value: unknown): value is Language {
+  return typeof value === "string" && SUPPORTED_LANGUAGES.includes(value as Language);
+}
+
+function isDiffFileMeta(value: unknown): value is DiffFileMeta {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const meta = value as Record<string, unknown>;
+
+  return (
+    typeof meta.name === "string" && typeof meta.size === "number" && typeof meta.type === "string"
+  );
+}
+
+export function isDiffSessionState(value: unknown): value is DiffSessionState {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const state = value as Record<string, unknown>;
+
+  return (
+    typeof state.leftContent === "string" &&
+    typeof state.rightContent === "string" &&
+    isLanguage(state.leftLang) &&
+    isLanguage(state.rightLang) &&
+    typeof state.changesOnly === "boolean" &&
+    (state.leftFile === null || isDiffFileMeta(state.leftFile)) &&
+    (state.rightFile === null || isDiffFileMeta(state.rightFile))
+  );
+}
+
+export function shouldPersistDiffSession(
+  state: Pick<DiffSessionState, "leftContent" | "rightContent">
+): boolean {
+  return state.leftContent.length + state.rightContent.length <= DIFF_SESSION_MAX_CHARS;
+}


### PR DESCRIPTION
## Summary
- add a small versioned local session persistence helper for tool state
- persist and restore diff inputs, detected languages, changes-only preference, and loaded file metadata across refreshes
- add focused tests for the generic session helper and diff session schema validation

## Closes
- Closes #66
- Closes #60
- Closes #13

## Verification
- `bun run type-check`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run format:check`

## Preview Testing
- Open the Vercel preview deployment from this PR once checks finish.
- Visit `/tools/diff`.
- Paste different content into both sides, switch one or both language selectors, and toggle `Changes only`.
- Refresh the page and confirm the content, selected languages, and toggle state are restored.
- Open a file on the left or right side and confirm the file name and size strip appears above the editor.
- Refresh the page and confirm the loaded content is restored and the file metadata strip is still shown for the correct side.
- Use `Swap` and confirm both the content and file metadata swap sides together.
- Clear both editors manually and refresh again; confirm the previous session no longer restores.