### PR TITLE
feat(diff): add TOML-aware structured compare

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/solid-js": "^5.1.3",
         "@fontsource-variable/manrope": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@iarna/toml": "^2.2.5",
         "astro": "^5.17.3",
         "diff": "^8.0.3",
         "lucide-solid": "^0.525.0",
@@ -369,6 +370,8 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@astrojs/solid-js": "^5.1.3",
     "@fontsource-variable/manrope": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@iarna/toml": "^2.2.5",
     "astro": "^5.17.3",
     "diff": "^8.0.3",
     "lucide-solid": "^0.525.0",

--- a/src/lib/language.ts
+++ b/src/lib/language.ts
@@ -1,6 +1,7 @@
 export const SUPPORTED_LANGUAGES = [
   "text",
   "json",
+  "toml",
   "yaml",
   "env",
   "javascript",
@@ -9,6 +10,9 @@ export const SUPPORTED_LANGUAGES = [
   "markdown",
   "xml",
   "html",
+  "ini",
+  "shell",
+  "dockerfile",
 ] as const;
 
 export type Language = (typeof SUPPORTED_LANGUAGES)[number];

--- a/src/lib/languageDetection.test.ts
+++ b/src/lib/languageDetection.test.ts
@@ -5,9 +5,17 @@ import { detectLanguage } from "./languageDetection";
 describe("language detection", () => {
   it("detects structured formats from filename extensions", () => {
     expect(detectLanguage({ filename: "config.json" })).toBe("json");
+    expect(detectLanguage({ filename: "pyproject.toml" })).toBe("toml");
     expect(detectLanguage({ filename: "docker-compose.yml" })).toBe("yaml");
     expect(detectLanguage({ filename: "workflow.yaml" })).toBe("yaml");
     expect(detectLanguage({ filename: "notes.md" })).toBe("markdown");
+  });
+
+  it("recognizes additional common developer text formats from filenames", () => {
+    expect(detectLanguage({ filename: "Dockerfile" })).toBe("dockerfile");
+    expect(detectLanguage({ filename: "nginx.conf" })).toBe("ini");
+    expect(detectLanguage({ filename: "setup.cfg" })).toBe("ini");
+    expect(detectLanguage({ filename: "deploy.sh" })).toBe("shell");
   });
 
   it("treats env-style files as text to preserve raw diffing", () => {
@@ -21,6 +29,10 @@ describe("language detection", () => {
 
   it("detects YAML-like content when no filename is present", () => {
     expect(detectLanguage({ content: "services:\n  api:\n    image: app:latest\n" })).toBe("yaml");
+  });
+
+  it("keeps TOML content detection conservative without a filename", () => {
+    expect(detectLanguage({ content: '[tool.poetry]\nname = "unwrapped"\n' })).toBe("text");
   });
 
   it("detects env content heuristically when it is just key-value pairs", () => {

--- a/src/lib/languageDetection.ts
+++ b/src/lib/languageDetection.ts
@@ -2,14 +2,21 @@ import { type Language } from "./language";
 
 const EXTENSION_LANGUAGE_MAP: Record<string, Language> = {
   ".env": "env",
+  ".bash": "shell",
+  ".conf": "ini",
+  ".config": "ini",
+  ".cfg": "ini",
   ".htm": "html",
   ".html": "html",
+  ".ini": "ini",
   ".js": "javascript",
   ".json": "json",
   ".jsx": "javascript",
   ".md": "markdown",
   ".markdown": "markdown",
   ".py": "python",
+  ".sh": "shell",
+  ".toml": "toml",
   ".ts": "typescript",
   ".tsx": "typescript",
   ".xml": "xml",
@@ -26,6 +33,10 @@ function detectFromFilename(filename: string): Language | null {
 
   if (lowerFilename === ".env" || lowerFilename.startsWith(".env.")) {
     return "env";
+  }
+
+  if (lowerFilename === "dockerfile") {
+    return "dockerfile";
   }
 
   const extension = Object.keys(EXTENSION_LANGUAGE_MAP).find((candidate) =>

--- a/src/lib/structuredCompare.test.ts
+++ b/src/lib/structuredCompare.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeEnvForDiff,
   normalizeJsonForDiff,
+  normalizeTomlForDiff,
   normalizeYamlForDiff,
   prepareStructuredCompare,
 } from "./structuredCompare";
@@ -105,6 +106,57 @@ describe("structured compare utilities", () => {
       strategy: "yaml",
       errors: [],
     });
+  });
+
+  it("normalizes TOML with stable key ordering", () => {
+    const result = normalizeTomlForDiff("b = 2\na = 1\n[tool]\nz = 3\na = 1\n");
+
+    expect(result).toEqual({
+      ok: true,
+      output: "a = 1\nb = 2\n\n[tool]\na = 1\nz = 3",
+    });
+  });
+
+  it("normalizes inline TOML tables into canonical TOML output", () => {
+    const result = normalizeTomlForDiff("tool = { z = 3, a = 1 }\n");
+
+    expect(result).toEqual({
+      ok: true,
+      output: "[tool]\na = 1\nz = 3",
+    });
+  });
+
+  it("uses normalized TOML when both sides are TOML", () => {
+    const result = prepareStructuredCompare({
+      original: "b = 2\na = 1\n[tool]\nz = 3\na = 1\n",
+      modified: "a = 1\nb = 2\n[tool]\na = 1\nz = 3\n",
+      leftLanguage: "toml",
+      rightLanguage: "toml",
+    });
+
+    expect(result).toEqual({
+      original: "a = 1\nb = 2\n\n[tool]\na = 1\nz = 3",
+      modified: "a = 1\nb = 2\n\n[tool]\na = 1\nz = 3",
+      strategy: "toml",
+      errors: [],
+    });
+  });
+
+  it("falls back to text diff and reports invalid TOML errors", () => {
+    const result = prepareStructuredCompare({
+      original: '[tool\nname = "broken"\n',
+      modified: 'name = "ok"\n',
+      leftLanguage: "toml",
+      rightLanguage: "toml",
+    });
+
+    expect(result.strategy).toBe("text");
+    expect(result.errors).toEqual([
+      {
+        side: "left",
+        message: expect.any(String),
+      },
+    ]);
   });
 
   it("normalizes env files by sorting keys and ignoring comments", () => {

--- a/src/lib/structuredCompare.ts
+++ b/src/lib/structuredCompare.ts
@@ -1,3 +1,5 @@
+import { parse as parseToml, stringify as stringifyToml } from "@iarna/toml";
+import type { JsonMap as TomlTable } from "@iarna/toml";
 import { parseAllDocuments, stringify } from "yaml";
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
@@ -10,7 +12,7 @@ export interface StructuredCompareError {
 export interface StructuredCompareResult {
   original: string;
   modified: string;
-  strategy: "text" | "json" | "yaml" | "env";
+  strategy: "text" | "json" | "toml" | "yaml" | "env";
   errors: StructuredCompareError[];
 }
 
@@ -27,6 +29,7 @@ interface NormalizeJsonFailure {
 type NormalizeJsonResult = NormalizeJsonSuccess | NormalizeJsonFailure;
 type NormalizeYamlResult = NormalizeJsonResult;
 type NormalizeEnvResult = NormalizeJsonResult;
+type NormalizeTomlResult = NormalizeJsonResult;
 
 function parseEnvKeyAndValue(line: string): { key: string; value: string } {
   const trimmedLine = line.trim();
@@ -165,6 +168,23 @@ function sortJsonValue(value: JsonValue): JsonValue {
   return value;
 }
 
+function sortTomlUnknown(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortTomlUnknown);
+  }
+
+  if (typeof value === "object" && value !== null && !(value instanceof Date)) {
+    return Object.keys(value)
+      .sort((leftKey, rightKey) => leftKey.localeCompare(rightKey))
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortTomlUnknown((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
 export function normalizeJsonForDiff(input: string): NormalizeJsonResult {
   if (input.trim().length === 0) {
     return { ok: true, output: "" };
@@ -213,6 +233,29 @@ export function normalizeYamlForDiff(input: string): NormalizeYamlResult {
     return {
       ok: false,
       message: error instanceof Error ? error.message : "Invalid YAML input",
+    };
+  }
+}
+
+export function normalizeTomlForDiff(input: string): NormalizeTomlResult {
+  if (input.trim().length === 0) {
+    return { ok: true, output: "" };
+  }
+
+  try {
+    const parsed = parseToml(input) as TomlTable;
+    const sorted = sortTomlUnknown(parsed) as TomlTable;
+
+    return {
+      ok: true,
+      output: stringifyToml(sorted as TomlTable)
+        .replace(/\r\n?/g, "\n")
+        .trimEnd(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Invalid TOML input",
     };
   }
 }
@@ -288,6 +331,37 @@ export function prepareStructuredCompare(input: {
           original: left.output,
           modified: right.output,
           strategy: "yaml",
+          errors: [],
+        };
+      }
+
+      const errors: StructuredCompareError[] = [];
+
+      if (!left.ok) {
+        errors.push({ side: "left", message: left.message });
+      }
+
+      if (!right.ok) {
+        errors.push({ side: "right", message: right.message });
+      }
+
+      return {
+        original,
+        modified,
+        strategy: "text",
+        errors,
+      };
+    }
+
+    if (leftLanguage === "toml" && rightLanguage === "toml") {
+      const left = normalizeTomlForDiff(original);
+      const right = normalizeTomlForDiff(modified);
+
+      if (left.ok && right.ok) {
+        return {
+          original: left.output,
+          modified: right.output,
+          strategy: "toml",
           errors: [],
         };
       }

--- a/src/tools/diff/DiffTool.tsx
+++ b/src/tools/diff/DiffTool.tsx
@@ -38,18 +38,23 @@ const DIFF_CONTEXT = 3;
 const LANGUAGE_LABELS: Record<Language, string> = {
   text: "Text",
   json: "JSON",
+  toml: "TOML",
   yaml: "YAML",
   env: ".env",
+  ini: "INI",
   javascript: "JavaScript",
   typescript: "TypeScript",
   python: "Python",
   markdown: "Markdown",
   xml: "XML",
   html: "HTML",
+  shell: "Shell",
+  dockerfile: "Dockerfile",
 };
 
 const STRATEGY_LABELS: Record<string, string> = {
   json: "Normalized JSON",
+  toml: "Normalized TOML",
   yaml: "Normalized YAML",
   env: "Normalized .env",
   text: "Text",

--- a/src/tools/diff/diffSession.test.ts
+++ b/src/tools/diff/diffSession.test.ts
@@ -8,7 +8,7 @@ describe("diff session schema", () => {
       isDiffSessionState({
         leftContent: "a",
         rightContent: "b",
-        leftLang: "json",
+        leftLang: "toml",
         rightLang: "yaml",
         changesOnly: true,
         leftFile: { name: "left.json", size: 10, type: "application/json" },
@@ -24,7 +24,7 @@ describe("diff session schema", () => {
         rightContent: "b",
         leftLang: "toml",
         rightLang: "yaml",
-        changesOnly: true,
+        changesOnly: "yes",
         leftFile: null,
         rightFile: null,
       })


### PR DESCRIPTION
## Summary
- add conservative `.toml` detection and normalized TOML compare support in the diff pipeline
- expand file-type labels for a small set of common developer text formats without implying deeper semantic support for them
- add tests for TOML normalization, TOML compare fallback behavior, and the new filename detection coverage

## Closes
- Closes #68
- Closes #62

## Verification
- `bun run type-check`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run format:check`

## Notes
- The added TOML parser emits Vite build warnings from its bundled implementation, but the production build and tests pass.
- Detection stays conservative: TOML semantic normalization only applies when both sides are explicitly recognized as `toml`.

## Preview Testing
- Open the Vercel preview deployment from this PR once checks finish.
- Visit `/tools/diff`.
- Open or paste two TOML documents with the same values but different key order and confirm the diff reports them as identical.
- Try a TOML document with inline tables or nested tables and confirm the strategy badge shows `Normalized TOML`.
- Break one side with invalid TOML syntax and confirm the tool falls back to text diff with a clear normalization error banner.
- Open files like `Dockerfile`, `setup.cfg`, `nginx.conf`, and `deploy.sh` and confirm the language selector updates to the new labels.
- Confirm those non-TOML formats still use plain text diff rather than incorrectly claiming semantic normalization.