### PR TITLE
refactor(platform): harden tool route execution

### DIFF
--- a/src/components/ToolErrorFallback.test.ts
+++ b/src/components/ToolErrorFallback.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { getToolErrorMessage } from "./ToolErrorFallback";
+
+describe("tool error fallback helpers", () => {
+  it("hides error details in production mode", () => {
+    expect(getToolErrorMessage(new Error("boom"), true)).toBeNull();
+  });
+
+  it("returns readable error details in development mode", () => {
+    expect(getToolErrorMessage(new Error("boom"), false)).toBe("boom");
+    expect(getToolErrorMessage("bad", false)).toBe("Unknown tool error");
+  });
+});

--- a/src/components/ToolErrorFallback.tsx
+++ b/src/components/ToolErrorFallback.tsx
@@ -1,0 +1,67 @@
+interface ToolErrorFallbackProps {
+  toolName: string;
+  onRetry?: () => void;
+  error?: unknown;
+}
+
+export function getToolErrorMessage(error: unknown, isProd: boolean): string | null {
+  if (isProd) {
+    return null;
+  }
+
+  return error instanceof Error ? error.message : "Unknown tool error";
+}
+
+function getErrorMessage(error: unknown): string | null {
+  return getToolErrorMessage(error, import.meta.env.PROD);
+}
+
+export default function ToolErrorFallback(props: ToolErrorFallbackProps) {
+  return (
+    <div
+      role="alert"
+      style={{
+        display: "flex",
+        "flex-direction": "column",
+        gap: "0.75rem",
+        padding: "1rem",
+        border: "1px solid var(--accent-error)",
+        "border-radius": "0.5rem",
+        background: "color-mix(in srgb, var(--accent-error) 10%, transparent)",
+        color: "var(--text-primary)",
+      }}
+    >
+      <div style={{ display: "flex", "flex-direction": "column", gap: "0.25rem" }}>
+        <strong style={{ color: "var(--accent-error)", "font-size": "0.9rem" }}>
+          {props.toolName} could not be loaded
+        </strong>
+        <span style={{ color: "var(--text-secondary)", "font-size": "0.85rem" }}>
+          The editor shell is still available. Retry the tool, or switch to another tool.
+        </span>
+        {getErrorMessage(props.error) ? (
+          <code style={{ color: "var(--text-muted)", "font-size": "0.75rem" }}>
+            {getErrorMessage(props.error)}
+          </code>
+        ) : null}
+      </div>
+
+      {props.onRetry ? (
+        <button
+          onClick={props.onRetry}
+          style={{
+            "align-self": "flex-start",
+            padding: "0.35rem 0.7rem",
+            "border-radius": "0.375rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+            "font-size": "0.8rem",
+          }}
+        >
+          Retry tool
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ToolHost.tsx
+++ b/src/components/ToolHost.tsx
@@ -1,17 +1,23 @@
+import { createSignal, ErrorBoundary, onMount, Show } from "solid-js";
 import type { Component } from "solid-js";
-import { createSignal, onMount, Show } from "solid-js";
 import { Dynamic, isServer } from "solid-js/web";
+
+import ToolErrorFallback from "@/components/ToolErrorFallback";
 
 interface ToolHostProps {
   componentPath: string;
+  toolName: string;
 }
 
 const toolModules = import.meta.glob<{ default: Component }>("../tools/*/*.tsx");
 
 export default function ToolHost(props: ToolHostProps) {
   const [toolComponent, setToolComponent] = createSignal<Component | null>(null);
+  const [loadError, setLoadError] = createSignal<unknown>(null);
 
-  onMount(async () => {
+  async function loadToolComponent() {
+    setLoadError(null);
+
     try {
       const modulePath = `../${props.componentPath.slice(5)}`;
       const loadTool = toolModules[modulePath];
@@ -23,13 +29,42 @@ export default function ToolHost(props: ToolHostProps) {
       const module = await loadTool();
       setToolComponent(() => module.default);
     } catch (error) {
+      setToolComponent(null);
+      setLoadError(error);
       console.error(error);
     }
+  }
+
+  onMount(async () => {
+    await loadToolComponent();
   });
 
   if (isServer) {
     return null;
   }
 
-  return <Show when={toolComponent()}>{(Component) => <Dynamic component={Component()} />}</Show>;
+  return (
+    <Show
+      when={toolComponent()}
+      fallback={
+        loadError() ? (
+          <ToolErrorFallback
+            toolName={props.toolName}
+            error={loadError()}
+            onRetry={() => void loadToolComponent()}
+          />
+        ) : null
+      }
+    >
+      {(Component) => (
+        <ErrorBoundary
+          fallback={(error, reset) => (
+            <ToolErrorFallback toolName={props.toolName} error={error} onRetry={reset} />
+          )}
+        >
+          <Dynamic component={Component()} />
+        </ErrorBoundary>
+      )}
+    </Show>
+  );
 }

--- a/src/lib/jsonFormatter.test.ts
+++ b/src/lib/jsonFormatter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { formatJson, parseJsonErrorPosition, syntaxHighlightJson } from "./jsonFormatter";
+
+describe("json formatter utilities", () => {
+  it("formats JSON with configurable indentation", () => {
+    const result = formatJson('{"b":2,"a":1}', 2, false);
+
+    expect(result.error).toBeNull();
+    expect(result.raw).toBe(`{
+  "b": 2,
+  "a": 1
+}`);
+  });
+
+  it("minifies JSON when requested", () => {
+    const result = formatJson(
+      `{
+      "a": 1,
+      "b": 2
+    }`,
+      2,
+      true
+    );
+
+    expect(result.raw).toBe('{"a":1,"b":2}');
+  });
+
+  it("returns parse errors for invalid JSON", () => {
+    const result = formatJson('{"a":1', 2, false);
+
+    expect(result.error).toContain("JSON parse error:");
+  });
+
+  it("extracts line or position details from parser messages", () => {
+    expect(parseJsonErrorPosition("Unexpected token at line 4")).toBe(4);
+    expect(parseJsonErrorPosition("Unexpected token at position 12")).toBe(12);
+  });
+
+  it("wraps highlighted JSON tokens in span elements", () => {
+    expect(syntaxHighlightJson('{"a":true}')).toContain("<span");
+  });
+});

--- a/src/lib/jsonFormatter.ts
+++ b/src/lib/jsonFormatter.ts
@@ -1,0 +1,63 @@
+export type IndentSize = 2 | 4;
+
+export interface JsonFormatResult {
+  html: string;
+  raw: string;
+  error: string | null;
+  errorLine: number | null;
+}
+
+export function syntaxHighlightJson(json: string): string {
+  return json
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(
+      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
+      (match) => {
+        let style = "color: var(--accent-primary)";
+        if (/^"/.test(match)) {
+          style = /:$/.test(match)
+            ? "color: var(--text-primary); font-weight: 600"
+            : "color: var(--accent-success)";
+        } else if (/true|false/.test(match)) {
+          style = "color: var(--accent-warning)";
+        } else if (/null/.test(match)) {
+          style = "color: var(--text-muted)";
+        }
+        return `<span style="${style}">${match}</span>`;
+      }
+    );
+}
+
+export function parseJsonErrorPosition(message: string): number | null {
+  const match = /line (\d+)/.exec(message) ?? /position (\d+)/.exec(message);
+  if (!match) return null;
+  return parseInt(match[1], 10);
+}
+
+export function formatJson(input: string, indent: IndentSize, minify: boolean): JsonFormatResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { html: "", raw: "", error: null, errorLine: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      html: "",
+      raw: "",
+      error: `JSON parse error: ${message}`,
+      errorLine: parseJsonErrorPosition(message),
+    };
+  }
+
+  const raw = minify ? JSON.stringify(parsed) : JSON.stringify(parsed, null, indent);
+  return {
+    html: syntaxHighlightJson(raw),
+    raw,
+    error: null,
+    errorLine: null,
+  };
+}

--- a/src/lib/jwt.test.ts
+++ b/src/lib/jwt.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeBase64Url, getJwtExpiryStatus, parseJwt, prettyJson } from "./jwt";
+
+describe("jwt utilities", () => {
+  it("decodes base64url JSON payloads", () => {
+    expect(decodeBase64Url("eyJmb28iOiJiYXIifQ")).toEqual({ foo: "bar" });
+  });
+
+  it("parses JWT tokens into header, payload, and signature", () => {
+    const token =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJleHAiOjE5MDAwMDAwMDB9.signature";
+
+    expect(parseJwt(token)).toEqual({
+      header: { alg: "HS256", typ: "JWT" },
+      payload: { sub: "123", exp: 1900000000 },
+      signature: "signature",
+    });
+  });
+
+  it("returns null for invalid JWT shapes", () => {
+    expect(parseJwt("not.a.jwt.extra")).toBeNull();
+  });
+
+  it("derives token expiry state from exp claims", () => {
+    expect(getJwtExpiryStatus({ exp: 100 }, 200)?.expired).toBe(true);
+    expect(getJwtExpiryStatus({ exp: 300 }, 200)?.expired).toBe(false);
+    expect(getJwtExpiryStatus({ sub: "123" }, 200)).toBeNull();
+  });
+
+  it("pretty prints arbitrary values", () => {
+    expect(prettyJson({ foo: "bar" })).toBe(`{
+  "foo": "bar"
+}`);
+  });
+});

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,76 @@
+export interface ParsedJwt {
+  header: unknown;
+  payload: unknown;
+  signature: string;
+}
+
+export interface JwtExpiryStatus {
+  expired: boolean;
+  label: string;
+}
+
+export function decodeBase64Url(str: string): unknown {
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+
+  let decoded: string;
+  try {
+    decoded = atob(padded);
+  } catch {
+    throw new Error("Invalid base64url encoding");
+  }
+
+  const utf8 = decodeURIComponent(
+    decoded
+      .split("")
+      .map((c) => "%" + c.charCodeAt(0).toString(16).padStart(2, "0"))
+      .join("")
+  );
+
+  try {
+    return JSON.parse(utf8) as unknown;
+  } catch {
+    return utf8;
+  }
+}
+
+export function parseJwt(token: string): ParsedJwt | null {
+  const parts = token.trim().split(".");
+  if (parts.length !== 3) return null;
+
+  const [rawHeader, rawPayload, signature] = parts;
+
+  try {
+    const header = decodeBase64Url(rawHeader);
+    const payload = decodeBase64Url(rawPayload);
+    return { header, payload, signature };
+  } catch {
+    return null;
+  }
+}
+
+export function prettyJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function formatJwtExpiry(exp: number): string {
+  return new Date(exp * 1000).toLocaleString();
+}
+
+export function getJwtExpiryStatus(
+  payload: unknown,
+  nowSeconds: number = Math.floor(Date.now() / 1000)
+): JwtExpiryStatus | null {
+  if (typeof payload !== "object" || payload === null) return null;
+
+  const exp = (payload as Record<string, unknown>)["exp"];
+  if (typeof exp !== "number") return null;
+
+  const expired = nowSeconds > exp;
+  return {
+    expired,
+    label: expired
+      ? `Token expired — ${formatJwtExpiry(exp)}`
+      : `Valid until ${formatJwtExpiry(exp)}`,
+  };
+}

--- a/src/lib/regex.test.ts
+++ b/src/lib/regex.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRegexResult, escapeHtml } from "./regex";
+
+describe("regex utilities", () => {
+  it("escapes HTML before highlighting", () => {
+    expect(escapeHtml("<tag>&")).toBe("&lt;tag&gt;&amp;");
+  });
+
+  it("builds regex results with matches and highlighting", () => {
+    const result = buildRegexResult("foo", new Set(["g"]), "foo bar foo");
+
+    expect(result.error).toBeNull();
+    expect(result.matches).toHaveLength(2);
+    expect(result.highlighted).toContain("<mark");
+  });
+
+  it("captures named and unnamed groups", () => {
+    const result = buildRegexResult("(?<word>foo)(bar)", new Set(["g"]), "foobar");
+
+    expect(result.matches[0]?.groups).toEqual([
+      { name: "word", value: "foo" },
+      { name: null, value: "bar" },
+    ]);
+  });
+
+  it("reports invalid regex patterns", () => {
+    const result = buildRegexResult("(", new Set(["g"]), "foo");
+
+    expect(result.error).toBeTruthy();
+    expect(result.matches).toEqual([]);
+  });
+});

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -1,0 +1,92 @@
+export type FlagKey = "g" | "i" | "m" | "s";
+
+export interface CaptureGroup {
+  name: string | null;
+  value: string;
+}
+
+export interface MatchResult {
+  index: number;
+  fullMatch: string;
+  groups: CaptureGroup[];
+}
+
+export interface RegexResult {
+  matches: MatchResult[];
+  highlighted: string;
+  error: string | null;
+}
+
+export function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function buildRegexResult(pattern: string, flags: Set<FlagKey>, input: string): RegexResult {
+  if (!pattern) {
+    return { matches: [], highlighted: escapeHtml(input), error: null };
+  }
+
+  let regex: RegExp;
+  const flagString = [...flags].join("");
+
+  try {
+    regex = new RegExp(pattern, flagString.includes("g") ? flagString : flagString + "g");
+  } catch (error) {
+    return {
+      matches: [],
+      highlighted: escapeHtml(input),
+      error: error instanceof Error ? error.message : "Invalid regular expression",
+    };
+  }
+
+  const matches: MatchResult[] = [];
+  const ranges: [number, number][] = [];
+
+  let match: RegExpExecArray | null;
+  let lastIndex = -1;
+
+  while ((match = regex.exec(input)) !== null) {
+    if (match.index === lastIndex) {
+      regex.lastIndex += 1;
+      continue;
+    }
+
+    lastIndex = match.index;
+    const groups: CaptureGroup[] = [];
+
+    if (match.groups) {
+      for (const [name, value] of Object.entries(match.groups)) {
+        groups.push({ name, value: value ?? "" });
+      }
+    }
+
+    for (let index = 1; index < match.length; index++) {
+      const alreadyNamed = match.groups && Object.values(match.groups).includes(match[index]);
+      if (!alreadyNamed && match[index] !== undefined) {
+        groups.push({ name: null, value: match[index] ?? "" });
+      }
+    }
+
+    matches.push({
+      index: match.index,
+      fullMatch: match[0],
+      groups,
+    });
+    ranges.push([match.index, match.index + match[0].length]);
+
+    if (!flagString.includes("g")) {
+      break;
+    }
+  }
+
+  let highlighted = "";
+  let position = 0;
+  for (const [start, end] of ranges) {
+    highlighted += escapeHtml(input.slice(position, start));
+    highlighted += `<mark style="background:color-mix(in srgb,var(--accent-primary) 30%,transparent);border-radius:2px;color:inherit;">${escapeHtml(input.slice(start, end))}</mark>`;
+    position = end;
+  }
+  highlighted += escapeHtml(input.slice(position));
+
+  return { matches, highlighted, error: null };
+}

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -42,7 +42,7 @@ if (!tool) {
 
     <!-- Tool component -->
     <div class="tool-body">
-      <ToolHost componentPath={tool.componentPath} client:load />
+      <ToolHost componentPath={tool.componentPath} toolName={tool.name} client:load />
     </div>
   </div>
 </EditorShell>

--- a/src/tools/json-formatter/JsonFormatter.tsx
+++ b/src/tools/json-formatter/JsonFormatter.tsx
@@ -1,85 +1,13 @@
 import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-type IndentSize = 2 | 4;
-
-interface FormatResult {
-  html: string;
-  raw: string;
-  error: string | null;
-  errorLine: number | null;
-}
-
-/** Very small tokenizer-based syntax highlighter (no shiki needed at runtime). */
-function syntaxHighlight(json: string): string {
-  return json
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(
-      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
-      (match) => {
-        let cls = "color: var(--accent-primary)"; // number
-        if (/^"/.test(match)) {
-          if (/:$/.test(match)) {
-            cls = "color: var(--text-primary); font-weight: 600"; // key
-          } else {
-            cls = "color: var(--accent-success)"; // string value
-          }
-        } else if (/true|false/.test(match)) {
-          cls = "color: var(--accent-warning)"; // boolean
-        } else if (/null/.test(match)) {
-          cls = "color: var(--text-muted)"; // null
-        }
-        return `<span style="${cls}">${match}</span>`;
-      }
-    );
-}
-
-/** Extract line/column from a JSON parse error message. */
-function parseErrorPosition(msg: string): number | null {
-  const match = /line (\d+)/.exec(msg) ?? /position (\d+)/.exec(msg);
-  if (!match) return null;
-  return parseInt(match[1], 10);
-}
-
-function formatJson(input: string, indent: IndentSize, minify: boolean): FormatResult {
-  const trimmed = input.trim();
-  if (!trimmed) return { html: "", raw: "", error: null, errorLine: null };
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed) as unknown;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return {
-      html: "",
-      raw: "",
-      error: `JSON parse error: ${msg}`,
-      errorLine: parseErrorPosition(msg),
-    };
-  }
-
-  const raw = minify ? JSON.stringify(parsed) : JSON.stringify(parsed, null, indent);
-
-  const html = syntaxHighlight(raw);
-  return { html, raw, error: null, errorLine: null };
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+import { formatJson, type IndentSize, type JsonFormatResult } from "@/lib/jsonFormatter";
 
 export default function JsonFormatter() {
   const [input, setInput] = createSignal("");
   const [indent, setIndent] = createSignal<IndentSize>(2);
   const [minify, setMinify] = createSignal(false);
-  const result = createMemo((): FormatResult => formatJson(input(), indent(), minify()));
+  const result = createMemo((): JsonFormatResult => formatJson(input(), indent(), minify()));
 
   const tabStyle = (active: boolean) => ({
     padding: "0.25rem 0.625rem",
@@ -105,9 +33,6 @@ export default function JsonFormatter() {
         width: "100%",
       }}
     >
-      {/* ------------------------------------------------------------------ */}
-      {/* Toolbar                                                             */}
-      {/* ------------------------------------------------------------------ */}
       <div
         style={{
           display: "flex",
@@ -116,7 +41,6 @@ export default function JsonFormatter() {
           gap: "0.75rem",
         }}
       >
-        {/* Indent toggle */}
         <div
           style={{
             display: "flex",
@@ -148,7 +72,6 @@ export default function JsonFormatter() {
           </button>
         </div>
 
-        {/* Minify toggle */}
         <button
           style={{
             padding: "0.25rem 0.75rem",
@@ -162,12 +85,11 @@ export default function JsonFormatter() {
             "font-weight": "600",
             cursor: "pointer",
           }}
-          onClick={() => setMinify((v) => !v)}
+          onClick={() => setMinify((value) => !value)}
         >
           Minify
         </button>
 
-        {/* Clear */}
         <Show when={input().trim()}>
           <button
             style={{
@@ -187,9 +109,6 @@ export default function JsonFormatter() {
         </Show>
       </div>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Input                                                               */}
-      {/* ------------------------------------------------------------------ */}
       <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
         <label
           style={{
@@ -227,9 +146,6 @@ export default function JsonFormatter() {
         />
       </div>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Error banner                                                        */}
-      {/* ------------------------------------------------------------------ */}
       <Show when={result().error}>
         {(msg) => (
           <div
@@ -249,9 +165,6 @@ export default function JsonFormatter() {
         )}
       </Show>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Output                                                              */}
-      {/* ------------------------------------------------------------------ */}
       <Show when={result().html}>
         {(html) => (
           <div
@@ -262,7 +175,6 @@ export default function JsonFormatter() {
               overflow: "hidden",
             }}
           >
-            {/* Output header */}
             <div
               style={{
                 display: "flex",
@@ -286,7 +198,6 @@ export default function JsonFormatter() {
               <CopyButton text={result().raw} />
             </div>
 
-            {/* Syntax-highlighted output */}
             <pre
               style={{
                 margin: "0",

--- a/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -1,72 +1,7 @@
 import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Convert a base64url string to standard base64 and decode it. */
-function decodeBase64Url(str: string): unknown {
-  // Replace base64url chars with standard base64 chars
-  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
-  // Pad to a multiple of 4
-  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
-
-  let decoded: string;
-  try {
-    decoded = atob(padded);
-  } catch {
-    throw new Error("Invalid base64url encoding");
-  }
-
-  // atob gives a binary string — decode as UTF-8 via percent-encoding trick
-  const utf8 = decodeURIComponent(
-    decoded
-      .split("")
-      .map((c) => "%" + c.charCodeAt(0).toString(16).padStart(2, "0"))
-      .join("")
-  );
-
-  try {
-    return JSON.parse(utf8) as unknown;
-  } catch {
-    // Non-JSON payload: return the raw string
-    return utf8;
-  }
-}
-
-interface ParsedJwt {
-  header: unknown;
-  payload: unknown;
-  signature: string;
-}
-
-/** Parse a JWT string into its three parts, or return null on failure. */
-function parseJwt(token: string): ParsedJwt | null {
-  const parts = token.trim().split(".");
-  if (parts.length !== 3) return null;
-
-  const [rawHeader, rawPayload, signature] = parts;
-
-  try {
-    const header = decodeBase64Url(rawHeader);
-    const payload = decodeBase64Url(rawPayload);
-    return { header, payload, signature };
-  } catch {
-    return null;
-  }
-}
-
-/** Pretty-print any value as JSON (2-space indent). */
-function prettyJson(value: unknown): string {
-  return JSON.stringify(value, null, 2);
-}
-
-/** Format a Unix timestamp (seconds) into a locale date+time string. */
-function formatExp(exp: number): string {
-  return new Date(exp * 1000).toLocaleString();
-}
+import { getJwtExpiryStatus, parseJwt, prettyJson } from "@/lib/jwt";
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -138,7 +73,7 @@ function Panel(props: PanelProps) {
 export default function JwtDecoder() {
   const [input, setInput] = createSignal("");
 
-  const parsed = createMemo((): ParsedJwt | null => {
+  const parsed = createMemo(() => {
     const raw = input().trim();
     if (!raw) return null;
     return parseJwt(raw);
@@ -152,22 +87,11 @@ export default function JwtDecoder() {
   });
 
   /** Expiry status derived from the payload's `exp` claim. */
-  const expiryStatus = createMemo((): { expired: boolean; label: string } | null => {
+  const expiryStatus = createMemo(() => {
     const result = parsed();
     if (!result) return null;
 
-    const payload = result.payload;
-    if (typeof payload !== "object" || payload === null) return null;
-
-    const exp = (payload as Record<string, unknown>)["exp"];
-    if (typeof exp !== "number") return null;
-
-    const now = Math.floor(Date.now() / 1000);
-    const expired = now > exp;
-    return {
-      expired,
-      label: expired ? `Token expired — ${formatExp(exp)}` : `Valid until ${formatExp(exp)}`,
-    };
+    return getJwtExpiryStatus(result.payload);
   });
 
   return (

--- a/src/tools/regex-tester/RegexTester.tsx
+++ b/src/tools/regex-tester/RegexTester.tsx
@@ -1,12 +1,7 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type FlagKey = "g" | "i" | "m" | "s";
+import { buildRegexResult, type FlagKey, type MatchResult } from "@/lib/regex";
 
 interface Flag {
   key: FlagKey;
@@ -20,105 +15,6 @@ const ALL_FLAGS: Flag[] = [
   { key: "m", label: "m", title: "Multiline — ^ and $ match line boundaries" },
   { key: "s", label: "s", title: "Dot-all — . matches newlines" },
 ];
-
-interface CaptureGroup {
-  name: string | null;
-  value: string;
-}
-
-interface MatchResult {
-  index: number;
-  fullMatch: string;
-  groups: CaptureGroup[];
-}
-
-interface RegexResult {
-  matches: MatchResult[];
-  highlighted: string; // HTML with <mark> tags
-  error: string | null;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function escapeHtml(str: string): string {
-  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-function buildResult(pattern: string, flags: Set<FlagKey>, input: string): RegexResult {
-  if (!pattern) {
-    return { matches: [], highlighted: escapeHtml(input), error: null };
-  }
-
-  let regex: RegExp;
-  const flagStr = [...flags].join("");
-  try {
-    // Always add 'd' (indices) if supported, fallback gracefully
-    regex = new RegExp(pattern, flagStr.includes("g") ? flagStr : flagStr + "g");
-  } catch (err) {
-    return {
-      matches: [],
-      highlighted: escapeHtml(input),
-      error: err instanceof Error ? err.message : "Invalid regular expression",
-    };
-  }
-
-  const matches: MatchResult[] = [];
-  const allMatchRanges: [number, number][] = [];
-
-  let m: RegExpExecArray | null;
-  // Guard against infinite loops from zero-width matches
-  let lastIndex = -1;
-  while ((m = regex.exec(input)) !== null) {
-    if (m.index === lastIndex) {
-      regex.lastIndex++;
-      continue;
-    }
-    lastIndex = m.index;
-
-    const groups: CaptureGroup[] = [];
-    if (m.groups) {
-      for (const [name, value] of Object.entries(m.groups)) {
-        groups.push({ name, value: value ?? "" });
-      }
-    }
-    // Also push unnamed capture groups (indices 1+) that aren't named
-    for (let i = 1; i < m.length; i++) {
-      // Only add if not already covered by named groups
-      const alreadyNamed = m.groups && Object.values(m.groups).includes(m[i]);
-      if (!alreadyNamed && m[i] !== undefined) {
-        groups.push({ name: null, value: m[i] ?? "" });
-      }
-    }
-
-    matches.push({
-      index: m.index,
-      fullMatch: m[0],
-      groups,
-    });
-
-    allMatchRanges.push([m.index, m.index + m[0].length]);
-
-    if (!flagStr.includes("g")) break;
-  }
-
-  // Build highlighted HTML
-  let highlighted = "";
-  let pos = 0;
-  for (const [start, end] of allMatchRanges) {
-    highlighted += escapeHtml(input.slice(pos, start));
-    highlighted += `<mark style="background:color-mix(in srgb,var(--accent-primary) 30%,transparent);border-radius:2px;color:inherit;">${escapeHtml(input.slice(start, end))}</mark>`;
-    pos = end;
-  }
-  highlighted += escapeHtml(input.slice(pos));
-
-  return { matches, highlighted, error: null };
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
 
 export default function RegexTester() {
   const [pattern, setPattern] = createSignal("");
@@ -137,21 +33,20 @@ export default function RegexTester() {
     });
   }
 
-  const result = createMemo((): RegexResult => buildResult(pattern(), flags(), input()));
-
+  const result = createMemo(() => buildRegexResult(pattern(), flags(), input()));
   const matchCount = createMemo(() => result().matches.length);
 
   const namedGroupNames = createMemo((): string[] => {
     const names = new Set<string>();
-    for (const m of result().matches) {
-      for (const g of m.groups) {
-        if (g.name) names.add(g.name);
+    for (const match of result().matches) {
+      for (const group of match.groups) {
+        if (group.name) names.add(group.name);
       }
     }
     return [...names];
   });
 
-  const hasCaptures = createMemo(() => result().matches.some((m) => m.groups.length > 0));
+  const hasCaptures = createMemo(() => result().matches.some((match) => match.groups.length > 0));
 
   const labelStyle = {
     "font-size": "0.75rem",
@@ -173,13 +68,8 @@ export default function RegexTester() {
         width: "100%",
       }}
     >
-      {/* ------------------------------------------------------------------ */}
-      {/* Pattern input + flags                                               */}
-      {/* ------------------------------------------------------------------ */}
       <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
         <label style={labelStyle}>Pattern</label>
-
-        {/* Pattern row */}
         <div
           style={{
             display: "flex",
@@ -191,7 +81,6 @@ export default function RegexTester() {
             transition: "border-color 0.15s",
           }}
         >
-          {/* Opening slash */}
           <span
             style={{
               padding: "0 0.5rem 0 0.875rem",
@@ -222,7 +111,6 @@ export default function RegexTester() {
             }}
           />
 
-          {/* Closing slash */}
           <span
             style={{
               color: "var(--text-muted)",
@@ -234,7 +122,6 @@ export default function RegexTester() {
             /
           </span>
 
-          {/* Flag toggles inline */}
           <div
             style={{
               display: "flex",
@@ -270,9 +157,6 @@ export default function RegexTester() {
         </div>
       </div>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Error banner                                                        */}
-      {/* ------------------------------------------------------------------ */}
       <Show when={result().error}>
         {(msg) => (
           <div
@@ -292,9 +176,6 @@ export default function RegexTester() {
         )}
       </Show>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Test string input                                                   */}
-      {/* ------------------------------------------------------------------ */}
       <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
         <label style={labelStyle}>Test string</label>
         <textarea
@@ -320,9 +201,6 @@ export default function RegexTester() {
         />
       </div>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Highlighted output                                                  */}
-      {/* ------------------------------------------------------------------ */}
       <Show when={input().trim()}>
         <div
           style={{
@@ -332,7 +210,6 @@ export default function RegexTester() {
             overflow: "hidden",
           }}
         >
-          {/* Header with match count */}
           <div
             style={{
               display: "flex",
@@ -346,14 +223,7 @@ export default function RegexTester() {
             <Show
               when={pattern() && !result().error}
               fallback={
-                <span
-                  style={{
-                    "font-size": "0.8125rem",
-                    color: "var(--text-muted)",
-                  }}
-                >
-                  —
-                </span>
+                <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>—</span>
               }
             >
               <span
@@ -372,7 +242,6 @@ export default function RegexTester() {
             </Show>
           </div>
 
-          {/* Highlighted text */}
           <pre
             style={{
               margin: "0",
@@ -390,9 +259,6 @@ export default function RegexTester() {
         </div>
       </Show>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Capture groups table                                                */}
-      {/* ------------------------------------------------------------------ */}
       <Show when={hasCaptures() && matchCount() > 0}>
         <div
           style={{
@@ -402,12 +268,7 @@ export default function RegexTester() {
             overflow: "hidden",
           }}
         >
-          <div
-            style={{
-              padding: "0.5rem 1rem",
-              "border-bottom": "1px solid var(--border)",
-            }}
-          >
+          <div style={{ padding: "0.5rem 1rem", "border-bottom": "1px solid var(--border)" }}>
             <span style={labelStyle}>Capture groups</span>
           </div>
 
@@ -463,7 +324,11 @@ export default function RegexTester() {
                       )}
                     </For>
                   </Show>
-                  <Show when={result().matches.some((m) => m.groups.some((g) => g.name === null))}>
+                  <Show
+                    when={result().matches.some((match) =>
+                      match.groups.some((group) => group.name === null)
+                    )}
+                  >
                     <th
                       style={{
                         padding: "0.5rem 1rem",
@@ -480,7 +345,7 @@ export default function RegexTester() {
               </thead>
               <tbody>
                 <For each={result().matches}>
-                  {(match, i) => (
+                  {(match: MatchResult, index) => (
                     <tr>
                       <td
                         style={{
@@ -490,7 +355,7 @@ export default function RegexTester() {
                           "white-space": "nowrap",
                         }}
                       >
-                        {i() + 1}
+                        {index() + 1}
                       </td>
                       <td
                         style={{
@@ -515,22 +380,22 @@ export default function RegexTester() {
                       <Show when={namedGroupNames().length > 0}>
                         <For each={namedGroupNames()}>
                           {(name) => {
-                            const g = match.groups.find((gr) => gr.name === name);
+                            const group = match.groups.find((candidate) => candidate.name === name);
                             return (
                               <td
                                 style={{
                                   padding: "0.375rem 1rem",
-                                  color: g ? "var(--accent-success)" : "var(--text-muted)",
+                                  color: group ? "var(--accent-success)" : "var(--text-muted)",
                                   "border-bottom": "1px solid var(--border)",
                                 }}
                               >
-                                {g ? g.value : "—"}
+                                {group ? group.value : "—"}
                               </td>
                             );
                           }}
                         </For>
                       </Show>
-                      <Show when={match.groups.some((g) => g.name === null)}>
+                      <Show when={match.groups.some((group) => group.name === null)}>
                         <td
                           style={{
                             padding: "0.375rem 1rem",
@@ -539,8 +404,8 @@ export default function RegexTester() {
                           }}
                         >
                           {match.groups
-                            .filter((g) => g.name === null)
-                            .map((g) => g.value)
+                            .filter((group) => group.name === null)
+                            .map((group) => group.value)
                             .join(", ")}
                         </td>
                       </Show>
@@ -553,15 +418,8 @@ export default function RegexTester() {
         </div>
       </Show>
 
-      {/* Empty state */}
       <Show when={!pattern() && !input().trim()}>
-        <p
-          style={{
-            "font-size": "0.8125rem",
-            color: "var(--text-muted)",
-            margin: "0",
-          }}
-        >
+        <p style={{ "font-size": "0.8125rem", color: "var(--text-muted)", margin: "0" }}>
           Enter a regex pattern and test string — matches are highlighted in real time
         </p>
       </Show>


### PR DESCRIPTION
## Summary
- add a shared tool error fallback and wrap interactive tool rendering in an error boundary so route shells survive load and runtime failures
- extract pure JWT, JSON formatter, and regex engines into `src/lib` so those tools keep UI concerns separate from reusable logic
- add focused unit coverage for the new fallback and extracted engines while preserving existing tool behavior

## Verification
- bun run lint
- bun run test
- bun run build
- bun run format:check

## Preview Testing
- open `/tools/jwt-decoder`, `/tools/json-formatter`, and `/tools/regex-tester` in the preview deployment and confirm their current workflows still behave as before
- confirm each route still renders its surrounding shell and recovery UI if the tool module fails to load or throws during render
- spot check another unaffected tool route such as `/tools/diff` to confirm the host change did not regress existing routes

## Issues
- Closes #20
- Progresses #53