### PR TITLE
fix(pwa): recover installed sessions into tool routes

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
         navigateFallback: "/",
+        navigateFallbackAllowlist: [/^\/$/],
       },
     }),
   ],

--- a/src/layouts/EditorShell.astro
+++ b/src/layouts/EditorShell.astro
@@ -2,6 +2,7 @@
 import { ViewTransitions } from "astro:transitions";
 
 import CommandPalette from "@/components/CommandPalette";
+import { getPwaRouteBootstrapScript } from "@/lib/pwaRoute";
 import SettingsModal from "@/components/SettingsModal";
 import { getThemeBootstrapScript } from "@/lib/theme";
 import "@/styles/global.css";
@@ -85,6 +86,8 @@ const grouped: GroupedTool[] = categoryOrder
     <link rel="manifest" href="/manifest.webmanifest" />
     <!-- Theme init: runs before paint to prevent flash -->
     <script is:inline set:html={getThemeBootstrapScript()} />
+    <!-- Restore the last tool route when an installed session reopens at home. -->
+    <script is:inline set:html={getPwaRouteBootstrapScript()} />
     <ViewTransitions />
   </head>
   <body>

--- a/src/lib/pwaRoute.test.ts
+++ b/src/lib/pwaRoute.test.ts
@@ -5,6 +5,7 @@ import {
   getRestorableToolRoute,
   getStandaloneRouteRecovery,
   LAST_TOOL_ROUTE_STORAGE_KEY,
+  shouldPersistToolRoute,
 } from "./pwaRoute";
 
 describe("pwaRoute", () => {
@@ -23,11 +24,18 @@ describe("pwaRoute", () => {
     expect(getStandaloneRouteRecovery("/", "/tools/regex-tester", false)).toBeNull();
   });
 
+  it("persists only registered tool routes", () => {
+    expect(shouldPersistToolRoute("/tools/json-formatter")).toBe(true);
+    expect(shouldPersistToolRoute("/")).toBe(false);
+    expect(shouldPersistToolRoute("/tools/not-real")).toBe(false);
+  });
+
   it("embeds the route recovery bootstrap inputs", () => {
     const script = getPwaRouteBootstrapScript();
 
     expect(script).toContain(LAST_TOOL_ROUTE_STORAGE_KEY);
     expect(script).toContain("/tools/diff");
     expect(script).toContain("window.location.replace(storedPathname)");
+    expect(script).toContain('document.addEventListener("astro:page-load", persistRoute)');
   });
 });

--- a/src/lib/pwaRoute.test.ts
+++ b/src/lib/pwaRoute.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPwaRouteBootstrapScript,
+  getRestorableToolRoute,
+  getStandaloneRouteRecovery,
+  LAST_TOOL_ROUTE_STORAGE_KEY,
+} from "./pwaRoute";
+
+describe("pwaRoute", () => {
+  it("accepts only registered tool routes for restore", () => {
+    expect(getRestorableToolRoute("/tools/diff")).toBe("/tools/diff");
+    expect(getRestorableToolRoute("/")).toBeNull();
+    expect(getRestorableToolRoute("/tools/not-real")).toBeNull();
+  });
+
+  it("recovers the last tool route only for standalone launches from home", () => {
+    expect(getStandaloneRouteRecovery("/", "/tools/regex-tester", true)).toBe(
+      "/tools/regex-tester"
+    );
+    expect(getStandaloneRouteRecovery("/", "/tools/not-real", true)).toBeNull();
+    expect(getStandaloneRouteRecovery("/tools/diff", "/tools/regex-tester", true)).toBeNull();
+    expect(getStandaloneRouteRecovery("/", "/tools/regex-tester", false)).toBeNull();
+  });
+
+  it("embeds the route recovery bootstrap inputs", () => {
+    const script = getPwaRouteBootstrapScript();
+
+    expect(script).toContain(LAST_TOOL_ROUTE_STORAGE_KEY);
+    expect(script).toContain("/tools/diff");
+    expect(script).toContain("window.location.replace(storedPathname)");
+  });
+});

--- a/src/lib/pwaRoute.ts
+++ b/src/lib/pwaRoute.ts
@@ -1,0 +1,53 @@
+import { getToolRoute, tools } from "../tools/registry";
+
+export const LAST_TOOL_ROUTE_STORAGE_KEY = "unwrapped-last-tool-route";
+
+const TOOL_ROUTES = tools.map((tool) => getToolRoute(tool.slug));
+
+export function getRestorableToolRoute(pathname: string | null | undefined): string | null {
+  return typeof pathname === "string" &&
+    TOOL_ROUTES.includes(pathname as (typeof TOOL_ROUTES)[number])
+    ? pathname
+    : null;
+}
+
+export function getStandaloneRouteRecovery(
+  pathname: string,
+  storedPathname: string | null | undefined,
+  isStandalone: boolean
+): string | null {
+  if (!isStandalone || pathname !== "/") {
+    return null;
+  }
+
+  return getRestorableToolRoute(storedPathname);
+}
+
+export function getPwaRouteBootstrapScript(): string {
+  return `(function () {
+  try {
+    const storageKey = ${JSON.stringify(LAST_TOOL_ROUTE_STORAGE_KEY)};
+    const validRoutes = ${JSON.stringify(TOOL_ROUTES)};
+    const pathname = window.location.pathname;
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      window.navigator.standalone === true;
+
+    if (validRoutes.includes(pathname)) {
+      localStorage.setItem(storageKey, pathname);
+      return;
+    }
+
+    if (pathname !== "/" || !isStandalone) {
+      return;
+    }
+
+    const storedPathname = localStorage.getItem(storageKey);
+    if (validRoutes.includes(storedPathname)) {
+      window.location.replace(storedPathname);
+    }
+  } catch {
+    // Ignore storage and browser capability failures during bootstrap.
+  }
+})();`;
+}

--- a/src/lib/pwaRoute.ts
+++ b/src/lib/pwaRoute.ts
@@ -23,29 +23,46 @@ export function getStandaloneRouteRecovery(
   return getRestorableToolRoute(storedPathname);
 }
 
+export function shouldPersistToolRoute(pathname: string): boolean {
+  return getRestorableToolRoute(pathname) !== null;
+}
+
 export function getPwaRouteBootstrapScript(): string {
   return `(function () {
   try {
     const storageKey = ${JSON.stringify(LAST_TOOL_ROUTE_STORAGE_KEY)};
     const validRoutes = ${JSON.stringify(TOOL_ROUTES)};
-    const pathname = window.location.pathname;
-    const isStandalone =
-      window.matchMedia("(display-mode: standalone)").matches ||
-      window.navigator.standalone === true;
+    const persistRoute = () => {
+      const pathname = window.location.pathname;
+      if (validRoutes.includes(pathname)) {
+        localStorage.setItem(storageKey, pathname);
+        return true;
+      }
 
-    if (validRoutes.includes(pathname)) {
-      localStorage.setItem(storageKey, pathname);
-      return;
+      return false;
+    };
+
+    const restoreRoute = () => {
+      const pathname = window.location.pathname;
+      const isStandalone =
+        window.matchMedia("(display-mode: standalone)").matches ||
+        window.navigator.standalone === true;
+
+      if (pathname !== "/" || !isStandalone) {
+        return;
+      }
+
+      const storedPathname = localStorage.getItem(storageKey);
+      if (validRoutes.includes(storedPathname)) {
+        window.location.replace(storedPathname);
+      }
+    };
+
+    if (!persistRoute()) {
+      restoreRoute();
     }
 
-    if (pathname !== "/" || !isStandalone) {
-      return;
-    }
-
-    const storedPathname = localStorage.getItem(storageKey);
-    if (validRoutes.includes(storedPathname)) {
-      window.location.replace(storedPathname);
-    }
+    document.addEventListener("astro:page-load", persistRoute);
   } catch {
     // Ignore storage and browser capability failures during bootstrap.
   }

--- a/src/test/routes.smoke.test.ts
+++ b/src/test/routes.smoke.test.ts
@@ -17,6 +17,12 @@ function readBuiltHtml(filePath: string): string {
   return readFileSync(absolutePath, "utf8");
 }
 
+function readBuiltAsset(filePath: string): string {
+  const absolutePath = resolve(distDir, filePath);
+  expect(existsSync(absolutePath)).toBe(true);
+  return readFileSync(absolutePath, "utf8");
+}
+
 beforeAll(() => {
   rmSync(distDir, { force: true, recursive: true });
 
@@ -31,6 +37,7 @@ describe("route smoke", () => {
     const html = readBuiltHtml("index.html");
 
     expect(html).toContain("unwrapped.tools");
+    expect(html).toContain("/manifest.webmanifest");
 
     for (const tool of tools) {
       expect(html).toContain(getToolRoute(tool.slug));
@@ -43,6 +50,17 @@ describe("route smoke", () => {
 
       expect(html).toContain(tool.name);
       expect(html).toContain(tool.description);
+      expect(html).toContain("/manifest.webmanifest");
     });
   }
+
+  it("precaches the home route and every registered tool route in the service worker", () => {
+    const serviceWorker = readBuiltAsset("sw.js");
+
+    expect(serviceWorker).toMatch(/"url":\s*"\/"/);
+
+    for (const tool of tools) {
+      expect(serviceWorker).toMatch(new RegExp(`"url":\\s*"${getToolRoute(tool.slug).slice(1)}"`));
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- limit the generated home-shell navigation fallback to `/` so offline tool deep links do not collapse into the homepage shell
- persist the last visited tool route and restore standalone launches from `/` back into that tool when an installed session reopens
- add route and service-worker smoke coverage for the manifest and precached tool entries used by offline sessions

## Verification
- bun run type-check
- bun run lint
- bun run test
- bun run build
- bun run format:check

## Preview Testing
- open `/tools/diff` and another tool route such as `/tools/json-formatter`, then install the PWA or open it in standalone mode and confirm reopening returns to the last visited tool instead of `/`
- after the service worker is installed, disable the network and revisit `/tools/diff` and `/tools/json-formatter` directly to confirm they still render the correct route shell
- disable the network and open `/tools/not-real` to confirm invalid deep links do not silently recover into the homepage shell

## Issues
- Closes #59
- Progresses #65