### PR TITLE
refactor(diff): move diff analysis off the main thread

### DIFF
--- a/src/lib/diff.worker.ts
+++ b/src/lib/diff.worker.ts
@@ -1,0 +1,14 @@
+import { analyzeDiff } from "./diffAnalysis";
+import type { DiffExecutionRequest, DiffExecutionResponse } from "./diffExecution";
+
+self.onmessage = (event: MessageEvent<DiffExecutionRequest>) => {
+  const response: DiffExecutionResponse = {
+    requestId: event.data.requestId,
+    result: analyzeDiff(event.data.input),
+    mode: "worker",
+  };
+
+  self.postMessage(response);
+};
+
+export {};

--- a/src/lib/diffAnalysis.test.ts
+++ b/src/lib/diffAnalysis.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeDiff } from "./diffAnalysis";
+
+describe("diffAnalysis", () => {
+  it("analyzes structured JSON diffs into normalized rows and stats", () => {
+    const result = analyzeDiff({
+      original: '{"b":2,"a":1}',
+      modified: '{"a":1,"b":3}',
+      leftLanguage: "json",
+      rightLanguage: "json",
+      changesOnly: true,
+    });
+
+    expect(result.strategy).toBe("json");
+    expect(result.errors).toEqual([]);
+    expect(result.stats).toEqual({ added: 1, removed: 1 });
+    expect(result.isIdentical).toBe(false);
+    expect(result.rows.some((row) => row.type === "changed")).toBe(true);
+    expect(result.filteredRows.length).toBeGreaterThan(0);
+    expect(result.changeIndices).toEqual([2]);
+  });
+
+  it("falls back to text diff with side specific structured errors", () => {
+    const result = analyzeDiff({
+      original: '{"a":',
+      modified: '{"a":1}',
+      leftLanguage: "json",
+      rightLanguage: "json",
+      changesOnly: true,
+    });
+
+    expect(result.strategy).toBe("text");
+    expect(result.errors).toEqual([expect.objectContaining({ side: "left" })]);
+    expect(result.rows.some((row) => row.type !== "equal")).toBe(true);
+  });
+
+  it("returns all rows when changes-only mode is disabled", () => {
+    const result = analyzeDiff({
+      original: "same\nold\n",
+      modified: "same\nnew\nextra\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: false,
+    });
+
+    expect(result.filteredRows).toHaveLength(result.rows.length);
+    expect(result.stats).toEqual({ added: 2, removed: 1 });
+  });
+
+  it("marks identical input as identical with no changes", () => {
+    const result = analyzeDiff({
+      original: "alpha\nbeta\n",
+      modified: "alpha\nbeta\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+
+    expect(result.isIdentical).toBe(true);
+    expect(result.stats).toEqual({ added: 0, removed: 0 });
+    expect(result.changeIndices).toEqual([]);
+  });
+});

--- a/src/lib/diffAnalysis.ts
+++ b/src/lib/diffAnalysis.ts
@@ -1,0 +1,61 @@
+import {
+  createDiffRows,
+  DIFF_CONTEXT,
+  type DiffRow,
+  type DiffStats,
+  filterRowsWithContext,
+  getChangeSourceIndices,
+  getDiffStats,
+  type IndexedDiffRow,
+} from "./diff";
+import type { Language } from "./language";
+import {
+  prepareStructuredCompare,
+  type StructuredCompareError,
+  type StructuredCompareResult,
+} from "./structuredCompare";
+
+export interface DiffAnalysisInput {
+  original: string;
+  modified: string;
+  leftLanguage: Language;
+  rightLanguage: Language;
+  changesOnly: boolean;
+  context?: number;
+}
+
+export interface DiffAnalysisResult {
+  strategy: StructuredCompareResult["strategy"];
+  errors: StructuredCompareError[];
+  rows: DiffRow[];
+  filteredRows: IndexedDiffRow[];
+  stats: DiffStats;
+  changeIndices: number[];
+  isIdentical: boolean;
+}
+
+export function analyzeDiff(input: DiffAnalysisInput): DiffAnalysisResult {
+  const preparedCompare = prepareStructuredCompare({
+    original: input.original,
+    modified: input.modified,
+    leftLanguage: input.leftLanguage,
+    rightLanguage: input.rightLanguage,
+  });
+  const rows = createDiffRows(preparedCompare.original, preparedCompare.modified);
+  const filteredRows = filterRowsWithContext(
+    rows,
+    input.changesOnly,
+    input.context ?? DIFF_CONTEXT
+  );
+  const stats = getDiffStats(rows);
+
+  return {
+    strategy: preparedCompare.strategy,
+    errors: preparedCompare.errors,
+    rows,
+    filteredRows,
+    stats,
+    changeIndices: getChangeSourceIndices(rows),
+    isIdentical: stats.added === 0 && stats.removed === 0,
+  };
+}

--- a/src/lib/diffExecution.browser.test.ts
+++ b/src/lib/diffExecution.browser.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import { analyzeDiff } from "./diffAnalysis";
+import {
+  createDiffAnalysisExecutor,
+  type DiffExecutionRequest,
+  type DiffExecutionResponse,
+} from "./diffExecution";
+
+interface MockWorker {
+  onerror: ((event: ErrorEvent) => void) | null;
+  onmessage: ((event: MessageEvent<DiffExecutionResponse>) => void) | null;
+  postMessage: (message: DiffExecutionRequest) => void;
+  postMessageSpy: ReturnType<typeof vi.fn>;
+  terminate: () => void;
+  terminateSpy: ReturnType<typeof vi.fn>;
+}
+
+function createMockWorker(
+  postMessage: (message: DiffExecutionRequest, worker: MockWorker) => void
+): MockWorker {
+  const postMessageSpy = vi.fn((message: DiffExecutionRequest) => postMessage(message, worker));
+  const terminateSpy = vi.fn();
+  const worker: MockWorker = {
+    onerror: null,
+    onmessage: null,
+    postMessage(message: DiffExecutionRequest) {
+      postMessageSpy(message);
+    },
+    postMessageSpy,
+    terminate() {
+      terminateSpy();
+    },
+    terminateSpy,
+  };
+
+  return worker;
+}
+
+describe("diffExecution browser runtime", () => {
+  it("uses the worker transport when the input crosses the threshold", async () => {
+    const worker = createMockWorker((message, currentWorker) => {
+      currentWorker.onmessage?.({
+        data: {
+          requestId: message.requestId,
+          result: analyzeDiff(message.input),
+          mode: "worker",
+        },
+      } as MessageEvent<DiffExecutionResponse>);
+    });
+    const executor = createDiffAnalysisExecutor({
+      createWorker: () => worker,
+      workerThresholdChars: 0,
+    });
+
+    const response = await executor.execute({
+      original: "alpha\nbeta\n",
+      modified: "alpha\ngamma\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+
+    expect(worker.postMessageSpy).toHaveBeenCalledTimes(1);
+    expect(response.mode).toBe("worker");
+    expect(response.result.stats).toEqual({ added: 1, removed: 1 });
+  });
+
+  it("falls back to sync execution when worker creation fails", async () => {
+    const executor = createDiffAnalysisExecutor({
+      createWorker: () => {
+        throw new Error("worker unavailable");
+      },
+      workerThresholdChars: 0,
+    });
+
+    const response = await executor.execute({
+      original: "alpha\n",
+      modified: "beta\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+
+    expect(response.mode).toBe("sync");
+  });
+
+  it("routes out-of-order worker responses back to the matching request", async () => {
+    const queue: Array<() => void> = [];
+    const worker = createMockWorker((message, currentWorker) => {
+      queue.push(() => {
+        currentWorker.onmessage?.({
+          data: {
+            requestId: message.requestId,
+            result: analyzeDiff(message.input),
+            mode: "worker",
+          },
+        } as MessageEvent<DiffExecutionResponse>);
+      });
+    });
+    const executor = createDiffAnalysisExecutor({
+      createWorker: () => worker,
+      workerThresholdChars: 0,
+    });
+
+    const firstPromise = executor.execute({
+      original: "first\n",
+      modified: "first changed\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+    const secondPromise = executor.execute({
+      original: "second\n",
+      modified: "second changed\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+
+    queue[1]?.();
+    queue[0]?.();
+
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    expect(first.requestId).toBe(1);
+    expect(second.requestId).toBe(2);
+    expect(first.result.rows[0]?.left).toBe("first");
+    expect(second.result.rows[0]?.left).toBe("second");
+  });
+
+  it("terminates the worker on dispose", async () => {
+    const worker = createMockWorker((message, currentWorker) => {
+      currentWorker.onmessage?.({
+        data: {
+          requestId: message.requestId,
+          result: analyzeDiff(message.input),
+          mode: "worker",
+        },
+      } as MessageEvent<DiffExecutionResponse>);
+    });
+    const executor = createDiffAnalysisExecutor({
+      createWorker: () => worker,
+      workerThresholdChars: 0,
+    });
+
+    await executor.execute({
+      original: "alpha\n",
+      modified: "beta\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+    executor.dispose();
+
+    expect(worker.terminateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/diffExecution.test.ts
+++ b/src/lib/diffExecution.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { createDiffAnalysisExecutor } from "./diffExecution";
+
+describe("diffExecution", () => {
+  it("executes synchronously when worker transport is unavailable", async () => {
+    const executor = createDiffAnalysisExecutor({
+      createWorker: () => null,
+      workerThresholdChars: 0,
+    });
+
+    await expect(
+      executor.execute({
+        original: "alpha\nbeta\n",
+        modified: "alpha\ngamma\n",
+        leftLanguage: "text",
+        rightLanguage: "text",
+        changesOnly: true,
+      })
+    ).resolves.toMatchObject({
+      mode: "sync",
+      requestId: 1,
+      result: {
+        stats: { added: 1, removed: 1 },
+      },
+    });
+  });
+
+  it("increments and preserves request ids across sequential calls", async () => {
+    const executor = createDiffAnalysisExecutor({
+      createWorker: () => null,
+    });
+
+    const first = await executor.execute({
+      original: "a\n",
+      modified: "b\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+    const second = await executor.execute({
+      original: "c\n",
+      modified: "d\n",
+      leftLanguage: "text",
+      rightLanguage: "text",
+      changesOnly: true,
+    });
+
+    expect(first.requestId).toBe(1);
+    expect(second.requestId).toBe(2);
+  });
+});

--- a/src/lib/diffExecution.ts
+++ b/src/lib/diffExecution.ts
@@ -1,0 +1,156 @@
+import { analyzeDiff, type DiffAnalysisInput, type DiffAnalysisResult } from "./diffAnalysis";
+
+export const DIFF_WORKER_THRESHOLD_CHARS = 75_000;
+
+export interface DiffExecutionRequest {
+  requestId: number;
+  input: DiffAnalysisInput;
+}
+
+export interface DiffExecutionResponse {
+  requestId: number;
+  result: DiffAnalysisResult;
+  mode: "sync" | "worker";
+}
+
+interface WorkerLike {
+  onerror: ((event: ErrorEvent) => void) | null;
+  onmessage: ((event: MessageEvent<DiffExecutionResponse>) => void) | null;
+  postMessage: (message: DiffExecutionRequest) => void;
+  terminate: () => void;
+}
+
+interface PendingWorkerRequest {
+  input: DiffAnalysisInput;
+  requestId: number;
+  resolve: (response: DiffExecutionResponse) => void;
+}
+
+export interface DiffAnalysisExecutor {
+  dispose: () => void;
+  execute: (input: DiffAnalysisInput) => Promise<DiffExecutionResponse>;
+}
+
+export interface DiffAnalysisExecutorOptions {
+  createWorker?: () => WorkerLike | null;
+  syncExecutor?: (input: DiffAnalysisInput) => DiffAnalysisResult;
+  workerThresholdChars?: number;
+}
+
+export function shouldUseDiffWorker(
+  input: Pick<DiffAnalysisInput, "original" | "modified">,
+  threshold = DIFF_WORKER_THRESHOLD_CHARS
+): boolean {
+  return input.original.length + input.modified.length >= threshold;
+}
+
+function createBrowserWorker(): WorkerLike | null {
+  if (typeof Worker === "undefined") {
+    return null;
+  }
+
+  return new Worker(new URL("./diff.worker.ts", import.meta.url), {
+    type: "module",
+  });
+}
+
+export function createDiffAnalysisExecutor(
+  options: DiffAnalysisExecutorOptions = {}
+): DiffAnalysisExecutor {
+  const syncExecutor = options.syncExecutor ?? analyzeDiff;
+  const createWorker = options.createWorker ?? createBrowserWorker;
+  const workerThresholdChars = options.workerThresholdChars ?? DIFF_WORKER_THRESHOLD_CHARS;
+
+  let nextRequestId = 0;
+  let worker: WorkerLike | null = null;
+  const pendingRequests = new Map<number, PendingWorkerRequest>();
+
+  function createSyncResponse(requestId: number, input: DiffAnalysisInput): DiffExecutionResponse {
+    return {
+      requestId,
+      result: syncExecutor(input),
+      mode: "sync",
+    };
+  }
+
+  function resolvePendingWithSyncFallback(): void {
+    const queuedRequests = Array.from(pendingRequests.values());
+    pendingRequests.clear();
+
+    for (const request of queuedRequests) {
+      request.resolve(createSyncResponse(request.requestId, request.input));
+    }
+  }
+
+  function disposeWorker(): void {
+    worker?.terminate();
+    worker = null;
+  }
+
+  function getWorker(): WorkerLike | null {
+    if (worker) {
+      return worker;
+    }
+
+    try {
+      worker = createWorker();
+    } catch {
+      worker = null;
+    }
+
+    if (!worker) {
+      return null;
+    }
+
+    worker.onmessage = (event) => {
+      const response = event.data;
+      const pendingRequest = pendingRequests.get(response.requestId);
+
+      if (!pendingRequest) {
+        return;
+      }
+
+      pendingRequests.delete(response.requestId);
+      pendingRequest.resolve({ ...response, mode: "worker" });
+    };
+
+    worker.onerror = () => {
+      disposeWorker();
+      resolvePendingWithSyncFallback();
+    };
+
+    return worker;
+  }
+
+  return {
+    dispose() {
+      disposeWorker();
+      resolvePendingWithSyncFallback();
+    },
+    execute(input) {
+      const requestId = ++nextRequestId;
+
+      if (!shouldUseDiffWorker(input, workerThresholdChars)) {
+        return Promise.resolve(createSyncResponse(requestId, input));
+      }
+
+      const activeWorker = getWorker();
+
+      if (!activeWorker) {
+        return Promise.resolve(createSyncResponse(requestId, input));
+      }
+
+      return new Promise((resolve) => {
+        pendingRequests.set(requestId, { input, requestId, resolve });
+
+        try {
+          activeWorker.postMessage({ requestId, input });
+        } catch {
+          pendingRequests.delete(requestId);
+          disposeWorker();
+          resolve(createSyncResponse(requestId, input));
+        }
+      });
+    },
+  };
+}

--- a/src/tools/diff/DiffTool.tsx
+++ b/src/tools/diff/DiffTool.tsx
@@ -9,17 +9,12 @@ import {
   Show,
 } from "solid-js";
 
-import {
-  createDiffRows,
-  filterRowsWithContext,
-  getChangeSourceIndices,
-  getDiffStats,
-} from "@/lib/diff";
+import { type DiffAnalysisResult } from "@/lib/diffAnalysis";
+import { createDiffAnalysisExecutor } from "@/lib/diffExecution";
 import { DEFAULT_IMPORT_MAX_BYTES, formatBytes, readImportedFile } from "@/lib/fileImport";
 import { type Language, SUPPORTED_LANGUAGES } from "@/lib/language";
 import { detectLanguage } from "@/lib/languageDetection";
 import { clearSessionState, loadSessionState, saveSessionState } from "@/lib/session";
-import { prepareStructuredCompare } from "@/lib/structuredCompare";
 import {
   DIFF_SESSION_STORAGE_KEY,
   DIFF_SESSION_VERSION,
@@ -34,6 +29,7 @@ import {
 
 const DEBOUNCE_MS = 400;
 const DIFF_CONTEXT = 3;
+const EMPTY_STATS = { added: 0, removed: 0 };
 
 const LANGUAGE_LABELS: Record<Language, string> = {
   text: "Text",
@@ -283,6 +279,8 @@ function InputPanel(props: InputPanelProps) {
 // ---------------------------------------------------------------------------
 
 export default function DiffTool() {
+  const diffExecutor = createDiffAnalysisExecutor();
+
   // --- State signals --------------------------------------------------------
   const [leftContent, setLeftContent] = createSignal("");
   const [rightContent, setRightContent] = createSignal("");
@@ -295,6 +293,7 @@ export default function DiffTool() {
   const [fileNotice, setFileNotice] = createSignal<string | null>(null);
   const [leftFile, setLeftFile] = createSignal<DiffFileMeta | null>(null);
   const [rightFile, setRightFile] = createSignal<DiffFileMeta | null>(null);
+  const [analysis, setAnalysis] = createSignal<DiffAnalysisResult | null>(null);
 
   // diffData holds the committed snapshot used for computing the diff
   const [diffData, setDiffData] = createSignal<{
@@ -303,6 +302,7 @@ export default function DiffTool() {
     leftLang: Language;
     rightLang: Language;
   } | null>(null);
+  let latestAnalysisRun = 0;
 
   // --- Debounced diff trigger -----------------------------------------------
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -340,6 +340,7 @@ export default function DiffTool() {
 
     if (left === "" && right === "") {
       setPending(false);
+      setAnalysis(null);
       setDiffData(null);
       return;
     }
@@ -348,10 +349,53 @@ export default function DiffTool() {
     debounceTimer = setTimeout(() => {
       batch(() => {
         setDiffData({ original: left, modified: right, leftLang: ll, rightLang: rl });
-        setPending(false);
         setCurrentChangeIdx(0);
       });
     }, DEBOUNCE_MS);
+  });
+
+  createEffect(() => {
+    const data = diffData();
+    const changesOnlyEnabled = changesOnly();
+    const runId = ++latestAnalysisRun;
+
+    if (!data) {
+      setAnalysis(null);
+      setPending(false);
+      return;
+    }
+
+    setPending(true);
+
+    void diffExecutor
+      .execute({
+        original: data.original,
+        modified: data.modified,
+        leftLanguage: data.leftLang,
+        rightLanguage: data.rightLang,
+        changesOnly: changesOnlyEnabled,
+        context: DIFF_CONTEXT,
+      })
+      .then((response) => {
+        if (runId !== latestAnalysisRun) {
+          return;
+        }
+
+        batch(() => {
+          setAnalysis(response.result);
+          setPending(false);
+        });
+      })
+      .catch(() => {
+        if (runId !== latestAnalysisRun) {
+          return;
+        }
+
+        batch(() => {
+          setAnalysis(null);
+          setPending(false);
+        });
+      });
   });
 
   createEffect(() => {
@@ -389,41 +433,23 @@ export default function DiffTool() {
 
   onCleanup(() => {
     if (debounceTimer !== null) clearTimeout(debounceTimer);
+    diffExecutor.dispose();
   });
 
   // --- Memos ----------------------------------------------------------------
-  const preparedCompare = createMemo(() => {
-    const data = diffData();
-    if (!data) return null;
-    return prepareStructuredCompare({
-      original: data.original,
-      modified: data.modified,
-      leftLanguage: data.leftLang,
-      rightLanguage: data.rightLang,
-    });
-  });
+  const filteredRows = createMemo(() => analysis()?.filteredRows ?? []);
 
-  const rows = createMemo(() => {
-    const compare = preparedCompare();
-    if (!compare) return [];
-    return createDiffRows(compare.original, compare.modified);
-  });
+  const stats = createMemo(() => analysis()?.stats ?? EMPTY_STATS);
 
-  const filteredRows = createMemo(() => filterRowsWithContext(rows(), changesOnly(), DIFF_CONTEXT));
+  const changeIndices = createMemo(() => analysis()?.changeIndices ?? []);
 
-  const stats = createMemo(() => getDiffStats(rows()));
+  const strategy = createMemo(() => analysis()?.strategy ?? "text");
 
-  const changeIndices = createMemo(() => getChangeSourceIndices(rows()));
-
-  const strategy = createMemo(() => preparedCompare()?.strategy ?? "text");
-
-  const structuredErrors = createMemo(() => preparedCompare()?.errors ?? []);
+  const structuredErrors = createMemo(() => analysis()?.errors ?? []);
 
   const isEmpty = createMemo(() => leftContent() === "" && rightContent() === "");
 
-  const isIdentical = createMemo(
-    () => diffData() !== null && !pending() && stats().added === 0 && stats().removed === 0
-  );
+  const isIdentical = createMemo(() => analysis()?.isIdentical ?? false);
 
   // --- File handling --------------------------------------------------------
   async function handleFileLoad(side: "left" | "right", file: File) {


### PR DESCRIPTION
## Summary
- extract the diff tool's pure compare pipeline into a reusable `diffAnalysis` module that returns strategy, structured errors, rows, filtered rows, stats, and change navigation indices
- add a worker-capable diff execution layer that offloads large analyses to a dedicated module worker while preserving a synchronous fallback for unsupported or failing environments
- update `DiffTool` to consume the async analysis result with stale-response protection, and add focused unit and browser-runtime coverage for the new execution path

## Verification
- bun run type-check
- bun run lint
- bun run test
- bun run build
- bun run format:check

## Preview Testing
- open `/tools/diff` with small inputs and confirm the tool still updates normally, including structured-format normalization, change counts, and next-change navigation
- compare a large enough pair of texts or configs to exercise the worker threshold and confirm the UI remains responsive while the analysis completes
- toggle `Changes only`, swap sides, and load files after large comparisons to confirm async diff execution does not break existing toolbar, persistence, or file-import behavior

## Issues
- Progresses #53
- Progresses #58