### PR TITLE
docs(product): define the tool and privacy contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This is the canonical instruction file for AI agents and contributors. `CLAUDE.m
 
 Stack: Astro 5 · SolidJS · Tailwind CSS v4 · TypeScript strict · Bun
 
-Deployment: Vercel · Domain: unwrapped.tools (pending)
+Deployment: Vercel at `https://unwrapped-tools.vercel.app` · Domain: `unwrapped.tools` pending
 
 ---
 
@@ -19,50 +19,66 @@ Deployment: Vercel · Domain: unwrapped.tools (pending)
 ```
 src/
 ├── components/
-│   ├── CommandPalette.tsx    # SolidJS, global Cmd+K palette
-│   ├── ThemePicker.tsx       # SolidJS, 4-theme switcher
-│   ├── CopyButton.tsx        # SolidJS, reusable copy button
-│   ├── ToolGrid.astro        # Homepage tool grid (reads registry)
-│   ├── ToolCard.astro        # Individual tool card
-│   └── ToolShell.astro       # Per-tool wrapper: title, meta, breadcrumb
+│   ├── CommandPalette.tsx     # SolidJS, global Cmd+K palette
+│   ├── CopyButton.tsx         # SolidJS, reusable copy button
+│   ├── SettingsModal.tsx      # Theme and local-data controls
+│   ├── ToolActionButton.tsx   # Shared action button baseline for tools
+│   ├── ToolErrorFallback.tsx  # Tool load failure UI
+│   ├── ToolHost.tsx           # Dynamic client tool loader + boundary
+│   └── ToolStatusMessage.tsx  # Shared status and notice UI
 ├── layouts/
-│   └── Base.astro            # Single HTML shell (replaces 3 old layouts)
+│   ├── Base.astro             # Standalone document shell for simple pages
+│   └── EditorShell.astro      # Main app shell for home and tool routes
 ├── pages/
-│   ├── index.astro           # / — Homepage
+│   ├── index.astro            # / — Tool suite index inside EditorShell
+│   ├── privacy.astro          # /privacy — local persistence contract
 │   └── tools/
-│       └── [slug].astro      # /tools/[slug] — Dynamic route (all tools)
+│       └── [slug].astro       # /tools/[slug] — Dynamic route for all tools
 ├── tools/
-│   ├── registry.ts           # SINGLE SOURCE OF TRUTH — all tool metadata
+│   ├── registry.ts            # SINGLE SOURCE OF TRUTH — all tool metadata
 │   ├── jwt-decoder/
-│   │   └── JwtDecoder.tsx    # Phase 1
+│   │   └── JwtDecoder.tsx
 │   ├── diff/
-│   │   └── DiffTool.tsx      # Phase 2
+│   │   ├── DiffTool.tsx
+│   │   ├── diffSession.ts
+│   │   └── diffSession.test.ts
 │   ├── base64/
-│   │   └── Base64Tool.tsx    # Phase 3
+│   │   └── Base64Tool.tsx
 │   ├── json-formatter/
-│   │   └── JsonFormatter.tsx # Phase 3
+│   │   └── JsonFormatter.tsx
 │   ├── hash-generator/
-│   │   └── HashGenerator.tsx # Phase 4
+│   │   └── HashGenerator.tsx
 │   ├── uuid-generator/
-│   │   └── UuidGenerator.tsx # Phase 4
+│   │   └── UuidGenerator.tsx
 │   ├── timestamp/
-│   │   └── TimestampTool.tsx # Phase 4
+│   │   └── TimestampTool.tsx
 │   └── regex-tester/
-│       └── RegexTester.tsx   # Phase 5
+│       └── RegexTester.tsx
 ├── lib/
+│   ├── clipboard.ts          # Shared copy helper with fallback support
 │   ├── diff.ts               # Diff engine (Myers algorithm via diff npm)
+│   ├── diffAnalysis.ts       # Pure diff analysis helpers
+│   ├── diffExecution.ts      # Main-thread or worker diff execution wrapper
+│   ├── diff.worker.ts        # Worker entry for large diff execution
 │   ├── diff.test.ts
-│   ├── structuredCompare.ts  # JSON/YAML/env normalization
-│   ├── structuredCompare.test.ts
-│   ├── languageDetection.ts  # File language heuristics
-│   ├── languageDetection.test.ts
+│   ├── fileImport.ts         # Shared file import policy and helpers
+│   ├── hash.ts               # Shared hash helpers
+│   ├── jsonFormatter.ts      # JSON formatting and highlighting helpers
+│   ├── jwt.ts                # JWT decode helpers
 │   ├── language.ts           # Language type + constants
+│   ├── languageDetection.ts  # File language heuristics
+│   ├── structuredCompare.test.ts
+│   ├── structuredCompare.ts  # JSON, TOML, YAML, and env normalization
+│   ├── localPersistence.ts   # Shared local-storage key registry
+│   ├── pwaRoute.ts           # Installed-session route recovery helpers
+│   ├── regex.ts              # Regex analysis helpers
 │   ├── search.ts             # Fuzzy search for command palette
-│   ├── clipboard.ts          # Copy to clipboard utility
-│   └── theme.ts              # Theme persistence (localStorage)
+│   ├── session.ts            # Versioned client session storage helpers
+│   ├── theme.ts              # Theme persistence and bootstrap helpers
+│   └── timestamp.ts          # Timestamp conversion helpers
 └── styles/
-    ├── themes.css            # 4 theme palettes as CSS custom properties
-    └── global.css            # Resets, typography, Tailwind import
+    ├── themes.css            # Theme palettes as CSS custom properties
+    └── global.css            # Global styles, fonts, Tailwind import
 ```
 
 ---
@@ -88,7 +104,7 @@ src/
 
 Four CSS palettes defined in `src/styles/themes.css` as `:root[data-theme="..."]` selectors.
 
-Available themes: `dracula` (default) · `catppuccin` · `nord` · `gruvbox`
+Available themes: `dracula` · `catppuccin` (default) · `nord` · `gruvbox`
 
 CSS custom properties (use these in all components):
 
@@ -98,7 +114,7 @@ CSS custom properties (use these in all components):
 - `--accent-success`, `--accent-warning`, `--accent-error`
 - `--border`
 
-Theme is persisted in `localStorage` under key `unwrapped-theme`. An inline script in `Base.astro` sets `data-theme` before first paint to prevent flash.
+Theme is persisted in `localStorage` under key `unwrapped-theme`. Inline bootstrap scripts in `Base.astro` and `EditorShell.astro` set `data-theme` before first paint to prevent flash.
 
 ---
 
@@ -108,9 +124,15 @@ Theme is persisted in `localStorage` under key `unwrapped-theme`. An inline scri
 
 1. Add an entry to the `tools` array in `registry.ts`
 2. Create `src/tools/[slug]/ToolName.tsx` (SolidJS component)
-3. Add the import + render in `src/pages/tools/[slug].astro`
+3. Ensure the registry `componentPath` matches the component file path under `src/tools/`
 
 Never hardcode tool metadata anywhere else.
+
+Tool responsibilities:
+
+- Tool components own tool-specific UI and orchestration.
+- Shared libs in `src/lib/` own reusable logic, persistence helpers, file import policy, clipboard behavior, and runtime guards.
+- Shared components in `src/components/` own repeated control patterns and failure boundaries.
 
 ---
 
@@ -140,18 +162,43 @@ All tool components are SolidJS `.tsx` files loaded with `client:load`.
 
 ---
 
+## Local-Only Engineering Baseline
+
+This repo is intentionally local-only. New features should preserve that baseline unless the user explicitly changes product direction.
+
+- Do not add server-side tool processing, uploads, analytics beacons, or third-party telemetry.
+- Do not persist tool inputs by default. If persistence is necessary, it must be documented, local-only, and registered in `src/lib/localPersistence.ts`.
+- Use `src/lib/fileImport.ts` for file reads so size limits and error handling stay consistent.
+- Service worker and PWA changes must preserve the local-only posture. Cached assets are fine; background upload or hidden sync is not.
+- Clipboard, local storage, and worker usage should be best-effort and fail safely.
+- Privacy and storage behavior exposed to users must stay aligned with `/privacy` and settings.
+
+Current registered local persistence keys:
+
+- `unwrapped-theme`
+- `unwrapped-last-tool-route`
+- `unwrapped-tool-session:diff`
+
+Current shared runtime limits:
+
+- Shared file import warning threshold: `512 KB`
+- Shared file import hard limit: `2 MB`
+- Diff persistence is preferences-only; compared content and imported file contents do not persist
+
+---
+
 ## Dependency Decisions
 
-| Need                              | Solution                          | Why                               |
-| --------------------------------- | --------------------------------- | --------------------------------- |
-| Diff algorithm                    | `diff` npm package                | Myers diff is solved CS           |
-| JWT decoding                      | Hand-rolled                       | Just `atob()` + padding fix       |
-| Hashing                           | Web Crypto API                    | Native browser                    |
-| UUID                              | `crypto.randomUUID()`             | Native browser                    |
-| Icons                             | `lucide-solid`                    | Tree-shakeable, developer-focused |
-| Themes                            | CSS custom properties             | Zero JS, zero runtime             |
-| Fuzzy search                      | Hand-rolled (`src/lib/search.ts`) | 30 lines, fast for 50 tools       |
-| Syntax highlight (JSON formatter) | `shiki` (Phase 3)                 | Zero runtime, VS Code quality     |
+| Need               | Solution                          | Why                                    |
+| ------------------ | --------------------------------- | -------------------------------------- |
+| Diff algorithm     | `diff` npm package                | Myers diff is solved CS                |
+| JWT decoding       | Hand-rolled                       | Just `atob()` + padding fix            |
+| Hashing            | Web Crypto API                    | Native browser                         |
+| UUID               | `crypto.randomUUID()`             | Native browser                         |
+| Icons              | `lucide-solid`                    | Tree-shakeable, developer-focused      |
+| Themes             | CSS custom properties             | Zero JS, zero runtime                  |
+| Fuzzy search       | Hand-rolled (`src/lib/search.ts`) | 30 lines, fast for 50 tools            |
+| JSON formatting UI | Shared formatter utilities        | Small, local-only, no heavy UI runtime |
 
 ---
 
@@ -176,6 +223,7 @@ Allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`
 ```
 feat/<short-description>
 fix/<short-description>
+docs/<short-description>
 ```
 
 ### PR Flow
@@ -190,4 +238,5 @@ Branch from `main` → commit → push → PR → CI must pass → squash merge
 
 - `ci.yml`: type-check, lint, format check, test, build on push/PR to main
 - `audit.yml`: weekly bun audit --prod
-- Production: Vercel at `https://unwrapped-tools.vercel.app` (domain: unwrapped.tools pending)
+- Production: Vercel at `https://unwrapped-tools.vercel.app` with `navigateFallback` limited to `/`
+- Installed standalone sessions can reopen the last visited tool route from local storage

--- a/README.md
+++ b/README.md
@@ -4,25 +4,41 @@
 
 No server. No uploads. No tracking.
 
-## Current tools
+## Product contract
 
-- JWT Decoder
-- Text Diff
-- Base64
-- JSON Formatter
-- Hash Generator
-- UUID Generator
-- Timestamp Converter
-- Regex Tester
+- Every shipped tool is registered in `src/tools/registry.ts` and served from `/tools/[slug]`.
+- Every tool runs inside the same editor-style shell and is loaded on the client.
+- Shared platform code owns persistence, file import policy, clipboard helpers, route recovery, and tool failure boundaries.
+- Tool inputs do not persist by default. Local persistence is limited to documented shell and preference state.
 
-## Product principles
+See `/privacy` in the app for the current local persistence contract and clear-data path.
 
-- Local-only processing: tool input stays on the device
-- Installable PWA: works offline after the first successful load
-- Shared shell: every tool route runs inside the same editor-style interface
-- Conservative persistence: preferences may persist locally, but tool inputs do not persist by default
+## Browser and runtime support
 
-See `/privacy` in the app for the current local persistence contract.
+- JavaScript is required for tool execution.
+- Modern browser APIs are required for the full experience: Web Crypto, `Intl.DateTimeFormat`, `navigator.clipboard`, file APIs, and Web Workers.
+- The PWA is installable and caches the app shell after the first successful load.
+- Offline navigation is conservative: the app falls back to `/`, and installed sessions can restore the last visited tool route from local storage.
+
+## Tool reference
+
+| Tool                | Example use                                          | Inputs and outputs                                                                                                                              | Runtime notes                                                                                           | Known limitations                                                                                                                                                                      |
+| ------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JWT Decoder         | Inspect a bearer token payload before debugging auth | Input: a 3-part JWT string. Output: decoded header, payload, signature segment, expiry state, copy actions.                                     | Uses `atob` and browser date APIs.                                                                      | Decode only. No signature verification or claim validation beyond basic expiry display.                                                                                                |
+| Text Diff           | Compare two config files before rollout              | Input: pasted text or one imported file per side. Output: side-by-side diff, change counts, navigation, swap, structured compare when possible. | Uses file APIs, drag and drop, local storage for diff preferences, and a worker path for heavier diffs. | File import is capped at 2 MB and warns above 512 KB. Structured normalization only applies when both sides are the same supported structured type. Compared content does not persist. |
+| Base64              | Encode a short token or decode a text payload        | Input: text or an imported file. Output: encoded or decoded text, copy, swap, file warnings.                                                    | Uses `btoa`, `atob`, `TextDecoder`, and file APIs.                                                      | Optimized for text workflows. Decoding assumes UTF-8 text output, and current file workflows should not be treated as arbitrary binary export support.                                 |
+| JSON Formatter      | Validate and pretty-print API payloads               | Input: JSON text. Output: formatted JSON, minified JSON, validation errors, syntax-highlighted preview, copy actions.                           | Uses built-in JSON parsing and formatting.                                                              | Strict JSON only. No JSON5, comments, or file import.                                                                                                                                  |
+| Hash Generator      | Generate a checksum for pasted content               | Input: text. Output: SHA-1, SHA-256, SHA-384, and SHA-512 hex digests.                                                                          | Uses `crypto.subtle.digest`.                                                                            | Text only. No file hashing, keyed hashing, or alternate encodings.                                                                                                                     |
+| UUID Generator      | Create a batch of IDs for fixtures or test data      | Input: count from 1 to 100 and optional uppercase mode. Output: UUID v4 list, copy one, copy all, reset.                                        | Uses `crypto.randomUUID` and clipboard APIs.                                                            | UUID v4 only. Count is capped at 100.                                                                                                                                                  |
+| Timestamp Converter | Convert an epoch value into human-readable dates     | Input: Unix timestamp text or `datetime-local`. Output: epoch seconds, epoch milliseconds, ISO timestamp, and timezone-specific renderings.     | Uses `Date` and `Intl.DateTimeFormat`.                                                                  | Seconds vs milliseconds is inferred by magnitude. Timezone choices are limited to the shipped presets.                                                                                 |
+| Regex Tester        | Validate a pattern against sample text               | Input: pattern, test string, and `g`, `i`, `m`, `s` flags. Output: live match highlighting, counts, capture groups, copy actions.               | Uses the browser JavaScript `RegExp` engine.                                                            | Only `g`, `i`, `m`, and `s` are exposed. No replace mode, Unicode flag controls, or file input yet.                                                                                    |
+
+## Local-only baseline
+
+- Tool content stays in the browser.
+- The app does not send tool inputs to a backend service.
+- Registered local persistence is limited to theme selection, installed-session route recovery, and diff view preferences.
+- Settings exposes `Clear local data`, which clears those registered values and resets the shell theme.
 
 ## Stack
 
@@ -46,4 +62,4 @@ bun run format
 bun run test
 ```
 
-See `AGENTS.md` for project conventions, architecture notes, and contributor instructions.
+See `AGENTS.md` for contributor instructions, the engineering baseline, and architecture notes.


### PR DESCRIPTION
## Summary
- redefine the product docs around the shipped multi-tool suite instead of the older diff-first shape
- document per-tool capabilities, browser requirements, and current limitations in the README
- update contributor guidance with the current repo structure and an explicit local-only engineering baseline

Closes #51
Closes #64
Closes #9

## Verification
- bun run type-check
- bun run lint
- bun run test
- bun run build
- bun run format:check

## Preview Validation
- review `README.md` to confirm the product contract, tool matrix, browser requirements, and local-only baseline match the shipped app
- review `AGENTS.md` to confirm the project structure, theme defaults, persistence rules, and PWA constraints match the current codebase
- spot-check `/privacy` and the current tool list to confirm the documented behavior aligns with the live routes and registered tools