### PR TITLE
feat(tools): deepen Base64 and Regex workflows

### DIFF
--- a/src/lib/base64.test.ts
+++ b/src/lib/base64.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeBase64ToBytes,
+  decodeBase64ToText,
+  encodeBytesToBase64,
+  encodeTextToBase64,
+  processBase64Input,
+  toBase64Url,
+} from "./base64";
+
+describe("base64 utilities", () => {
+  it("encodes and decodes standard base64 text", () => {
+    const encoded = encodeTextToBase64("hello world", "standard");
+
+    expect(encoded).toBe("aGVsbG8gd29ybGQ=");
+    expect(decodeBase64ToText(encoded, "standard")).toBe("hello world");
+  });
+
+  it("encodes and decodes base64url text", () => {
+    const encoded = encodeTextToBase64("hello?", "url");
+
+    expect(encoded).toBe(toBase64Url("aGVsbG8/"));
+    expect(decodeBase64ToText(encoded, "url")).toBe("hello?");
+  });
+
+  it("encodes bytes directly for file workflows", () => {
+    expect(encodeBytesToBase64(new Uint8Array([0, 255, 16]), "standard")).toBe("AP8Q");
+  });
+
+  it("decodes binary output for file workflows", () => {
+    expect(Array.from(decodeBase64ToBytes("AP8Q", "standard"))).toEqual([0, 255, 16]);
+  });
+
+  it("reports invalid text decode input", () => {
+    expect(processBase64Input("a", "decode", "standard", "text")).toEqual({
+      ok: false,
+      error:
+        "Invalid input for the selected Base64 variant, or the decoded bytes are not valid UTF-8 text.",
+    });
+  });
+
+  it("returns a byte summary for binary decode workflows", () => {
+    const result = processBase64Input("AP8Q", "decode", "standard", "file");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.outputKind).toBe("bytes");
+      expect(result.value).toContain("3 bytes");
+      expect(result.value).toContain("00 ff 10");
+    }
+  });
+});

--- a/src/lib/base64.ts
+++ b/src/lib/base64.ts
@@ -1,0 +1,146 @@
+import { DEFAULT_IMPORT_MAX_BYTES, formatBytes, type ImportedFileMeta } from "./fileImport";
+
+export type Base64Variant = "standard" | "url";
+export type Base64Mode = "encode" | "decode";
+export type Base64Workflow = "text" | "file";
+export type Base64DecodeOutputKind = "text" | "bytes";
+
+export interface Base64TransformSuccess {
+  ok: true;
+  value: string;
+  outputKind: Base64DecodeOutputKind;
+}
+
+export interface Base64TransformFailure {
+  ok: false;
+  error: string;
+}
+
+export type Base64TransformResult = Base64TransformSuccess | Base64TransformFailure;
+
+export function encodeTextToBase64(input: string, variant: Base64Variant): string {
+  return encodeBytesToBase64(new TextEncoder().encode(input), variant);
+}
+
+export function encodeBytesToBase64(bytes: Uint8Array, variant: Base64Variant): string {
+  let binary = "";
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  const encoded = btoa(binary);
+
+  return variant === "url" ? toBase64Url(encoded) : encoded;
+}
+
+export function decodeBase64ToBytes(input: string, variant: Base64Variant): Uint8Array {
+  const normalized = normalizeBase64Input(input, variant);
+  const binary = atob(normalized);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
+}
+
+export function decodeBase64ToText(input: string, variant: Base64Variant): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(decodeBase64ToBytes(input, variant));
+}
+
+export function processBase64Input(
+  input: string,
+  mode: Base64Mode,
+  variant: Base64Variant,
+  workflow: Base64Workflow
+): Base64TransformResult {
+  if (!input.trim()) {
+    return {
+      ok: true,
+      value: "",
+      outputKind: mode === "encode" ? "text" : workflow === "file" ? "bytes" : "text",
+    };
+  }
+
+  try {
+    if (mode === "encode") {
+      return {
+        ok: true,
+        value: workflow === "text" ? encodeTextToBase64(input, variant) : input,
+        outputKind: "text",
+      };
+    }
+
+    if (workflow === "file") {
+      const bytes = decodeBase64ToBytes(input, variant);
+      return {
+        ok: true,
+        value: formatByteSummary(bytes),
+        outputKind: "bytes",
+      };
+    }
+
+    return {
+      ok: true,
+      value: decodeBase64ToText(input, variant),
+      outputKind: "text",
+    };
+  } catch {
+    return {
+      ok: false,
+      error:
+        mode === "decode"
+          ? workflow === "file"
+            ? "Invalid input for the selected Base64 variant. Binary decode could not be completed."
+            : "Invalid input for the selected Base64 variant, or the decoded bytes are not valid UTF-8 text."
+          : "Encoding failed for the current input.",
+    };
+  }
+}
+
+export function formatBase64FileNotice(
+  file: ImportedFileMeta,
+  mode: Base64Mode,
+  workflow: Base64Workflow
+): string {
+  const operation = mode === "encode" ? "encode" : workflow === "file" ? "inspect" : "decode";
+  return `${file.name} is ${formatBytes(file.size)}. Large files may take longer to ${operation}.`;
+}
+
+export function formatBase64FileTooLargeMessage(
+  maxBytes: number = DEFAULT_IMPORT_MAX_BYTES
+): string {
+  return `File is too large. Maximum supported size is ${formatBytes(maxBytes)}.`;
+}
+
+export function toBase64Url(value: string): string {
+  return value.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function normalizeBase64Input(input: string, variant: Base64Variant): string {
+  const trimmed = input.trim();
+  const sanitized = variant === "url" ? trimmed.replace(/-/g, "+").replace(/_/g, "/") : trimmed;
+
+  if (sanitized.length === 0) {
+    return sanitized;
+  }
+
+  const remainder = sanitized.length % 4;
+  if (remainder === 1) {
+    throw new Error("Invalid base64 length");
+  }
+
+  return remainder === 0 ? sanitized : sanitized + "=".repeat(4 - remainder);
+}
+
+function formatByteSummary(bytes: Uint8Array): string {
+  const preview = Array.from(bytes.slice(0, 32))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join(" ");
+
+  return bytes.length <= 32
+    ? `${bytes.length} bytes\n${preview}`
+    : `${bytes.length} bytes\n${preview}\n...`;
+}

--- a/src/lib/regex.test.ts
+++ b/src/lib/regex.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildRegexResult, escapeHtml } from "./regex";
+import { buildRegexReplaceResult, buildRegexResult, escapeHtml } from "./regex";
 
 describe("regex utilities", () => {
   it("escapes HTML before highlighting", () => {
@@ -13,6 +13,7 @@ describe("regex utilities", () => {
     expect(result.error).toBeNull();
     expect(result.matches).toHaveLength(2);
     expect(result.highlighted).toContain("<mark");
+    expect(result.summary.firstMatchIndex).toBe(0);
   });
 
   it("captures named and unnamed groups", () => {
@@ -29,5 +30,21 @@ describe("regex utilities", () => {
 
     expect(result.error).toBeTruthy();
     expect(result.matches).toEqual([]);
+  });
+
+  it("builds replacement results", () => {
+    const result = buildRegexReplaceResult("foo", new Set(["g"]), "foo bar foo", "baz");
+
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.output).toBe("baz bar baz");
+      expect(result.replacements).toBe(2);
+    }
+  });
+
+  it("tracks empty matches in the summary", () => {
+    const result = buildRegexResult("^", new Set(["g", "m"]), "foo\nbar");
+
+    expect(result.summary.emptyMatchCount).toBeGreaterThan(0);
   });
 });

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -11,10 +11,22 @@ export interface MatchResult {
   groups: CaptureGroup[];
 }
 
+export interface RegexSummary {
+  captureGroupCount: number;
+  emptyMatchCount: number;
+  firstMatchIndex: number | null;
+}
+
+export interface RegexReplaceResult {
+  output: string;
+  replacements: number;
+}
+
 export interface RegexResult {
   matches: MatchResult[];
   highlighted: string;
   error: string | null;
+  summary: RegexSummary;
 }
 
 export function escapeHtml(str: string): string {
@@ -23,7 +35,12 @@ export function escapeHtml(str: string): string {
 
 export function buildRegexResult(pattern: string, flags: Set<FlagKey>, input: string): RegexResult {
   if (!pattern) {
-    return { matches: [], highlighted: escapeHtml(input), error: null };
+    return {
+      matches: [],
+      highlighted: escapeHtml(input),
+      error: null,
+      summary: createSummary([]),
+    };
   }
 
   let regex: RegExp;
@@ -36,6 +53,7 @@ export function buildRegexResult(pattern: string, flags: Set<FlagKey>, input: st
       matches: [],
       highlighted: escapeHtml(input),
       error: error instanceof Error ? error.message : "Invalid regular expression",
+      summary: createSummary([]),
     };
   }
 
@@ -88,5 +106,70 @@ export function buildRegexResult(pattern: string, flags: Set<FlagKey>, input: st
   }
   highlighted += escapeHtml(input.slice(position));
 
-  return { matches, highlighted, error: null };
+  return { matches, highlighted, error: null, summary: createSummary(matches) };
+}
+
+export function buildRegexReplaceResult(
+  pattern: string,
+  flags: Set<FlagKey>,
+  input: string,
+  replacement: string
+): RegexReplaceResult | { error: string } {
+  if (!pattern) {
+    return {
+      output: input,
+      replacements: 0,
+    };
+  }
+
+  let regex: RegExp;
+  const flagString = [...flags].join("");
+
+  try {
+    regex = new RegExp(pattern, flagString);
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "Invalid regular expression",
+    };
+  }
+
+  const output = input.replace(regex, replacement);
+  const replacements = countReplacements(pattern, flagString, input);
+
+  return {
+    output,
+    replacements,
+  };
+}
+
+function createSummary(matches: MatchResult[]): RegexSummary {
+  return {
+    captureGroupCount: matches.reduce((total, match) => total + match.groups.length, 0),
+    emptyMatchCount: matches.filter((match) => match.fullMatch.length === 0).length,
+    firstMatchIndex: matches[0]?.index ?? null,
+  };
+}
+
+function countReplacements(pattern: string, flagString: string, input: string): number {
+  const regex = new RegExp(pattern, flagString);
+
+  if (!flagString.includes("g")) {
+    return regex.test(input) ? 1 : 0;
+  }
+
+  let count = 0;
+  let match: RegExpExecArray | null;
+  let lastIndex = -1;
+
+  while ((match = regex.exec(input)) !== null) {
+    if (match.index === lastIndex) {
+      regex.lastIndex += 1;
+      continue;
+    }
+
+    lastIndex = match.index;
+    count += 1;
+  }
+
+  return count;
 }

--- a/src/tools/base64/Base64Tool.tsx
+++ b/src/tools/base64/Base64Tool.tsx
@@ -1,89 +1,103 @@
-import { createSignal, Show } from "solid-js";
+import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
+import ToolActionButton from "@/components/ToolActionButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import {
+  type Base64Mode,
+  type Base64Variant,
+  type Base64Workflow,
+  encodeBytesToBase64,
+  formatBase64FileNotice,
+  formatBase64FileTooLargeMessage,
+  processBase64Input,
+} from "@/lib/base64";
 import {
   DEFAULT_IMPORT_MAX_BYTES,
   type FileImportError,
   formatBytes,
+  type ImportedFileMeta,
   readImportedFile,
 } from "@/lib/fileImport";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-type Mode = "encode" | "decode";
-
-/** Encode a string to base64 (UTF-8 safe). */
-function encodeBase64(input: string): string {
-  return btoa(
-    encodeURIComponent(input).replace(/%([0-9A-F]{2})/g, (_, p1: string) =>
-      String.fromCharCode(parseInt(p1, 16))
-    )
-  );
-}
-
-/** Decode a base64 string back to UTF-8. */
-function decodeBase64(input: string): string {
-  const binary = atob(input.trim());
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new TextDecoder().decode(bytes);
-}
-
-interface Result {
-  value: string;
-  error: string | null;
-}
-
-function encodeBytesToBase64(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
-}
-
-function process(input: string, mode: Mode): Result {
-  const trimmed = input.trim();
-  if (!trimmed) return { value: "", error: null };
-  try {
-    if (mode === "encode") {
-      return { value: encodeBase64(trimmed), error: null };
-    } else {
-      return { value: decodeBase64(trimmed), error: null };
-    }
-  } catch {
-    return {
-      value: "",
-      error:
-        mode === "decode"
-          ? "Invalid base64 — input contains characters outside the base64 alphabet."
-          : "Encoding failed — input may contain unsupported characters.",
-    };
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
 export default function Base64Tool() {
-  const [mode, setMode] = createSignal<Mode>("encode");
+  const [mode, setMode] = createSignal<Base64Mode>("encode");
+  const [variant, setVariant] = createSignal<Base64Variant>("standard");
+  const [workflow, setWorkflow] = createSignal<Base64Workflow>("text");
   const [input, setInput] = createSignal("");
   const [fileError, setFileError] = createSignal<FileImportError | null>(null);
+  const [loadedFile, setLoadedFile] = createSignal<ImportedFileMeta | null>(null);
+  const [loadedFileBytes, setLoadedFileBytes] = createSignal<Uint8Array | null>(null);
   const [fileNotice, setFileNotice] = createSignal<string | null>(null);
 
-  const result = (): Result => process(input(), mode());
+  const textInput = createMemo(() => (mode() === "encode" && workflow() === "file" ? "" : input()));
+  const result = createMemo(() => {
+    if (mode() === "encode" && workflow() === "file" && loadedFileBytes()) {
+      return {
+        ok: true as const,
+        value: encodeBytesToBase64(loadedFileBytes() ?? new Uint8Array(), variant()),
+        outputKind: "text" as const,
+      };
+    }
+
+    return processBase64Input(textInput(), mode(), variant(), workflow());
+  });
+  const outputValue = createMemo(() => {
+    const current = result();
+    return current.ok ? current.value : "";
+  });
+  const transformError = createMemo(() => {
+    const current = result();
+    return current.ok ? null : current.error;
+  });
+  const fileSummary = createMemo(() => {
+    const file = loadedFile();
+    if (!file) {
+      return "";
+    }
+
+    return `${file.name}\n${formatBytes(file.size)}${file.type ? `\n${file.type}` : ""}`;
+  });
 
   function swap() {
-    const current = result().value;
+    const current = outputValue();
     setFileError(null);
     setFileNotice(null);
+    setLoadedFile(null);
+    setLoadedFileBytes(null);
     setMode((m) => (m === "encode" ? "decode" : "encode"));
     setInput(current);
+  }
+
+  function reset() {
+    setMode("encode");
+    setVariant("standard");
+    setWorkflow("text");
+    setInput("");
+    setFileError(null);
+    setLoadedFile(null);
+    setLoadedFileBytes(null);
+    setFileNotice(null);
+  }
+
+  function handleModeChange(nextMode: Base64Mode) {
+    setMode(nextMode);
+    setLoadedFile(null);
+    setLoadedFileBytes(null);
+    setFileError(null);
+    setFileNotice(null);
+  }
+
+  function handleWorkflowChange(nextWorkflow: Base64Workflow) {
+    setWorkflow(nextWorkflow);
+    setLoadedFile(null);
+    setLoadedFileBytes(null);
+    setFileError(null);
+    setFileNotice(null);
   }
 
   async function handleFile(file: File) {
@@ -102,19 +116,28 @@ export default function Base64Tool() {
       }
 
       if (result.decision.status === "warn") {
-        setFileNotice(
-          `${file.name} is ${formatBytes(result.file.size)}. Large files may take longer to encode.`
-        );
+        setFileNotice(formatBase64FileNotice(result.file, mode(), workflow()));
       }
 
-      setInput(encodeBytesToBase64(result.value));
+      setLoadedFile(result.file);
+      setLoadedFileBytes(result.value);
+      setWorkflow("file");
+      setInput("");
       return;
     }
 
-    const result = await readImportedFile(file, {
-      as: "text",
-      policy: { maxBytes: DEFAULT_IMPORT_MAX_BYTES },
-    });
+    const result = await readImportedFile(
+      file,
+      workflow() === "file"
+        ? {
+            as: "text",
+            policy: { maxBytes: DEFAULT_IMPORT_MAX_BYTES },
+          }
+        : {
+            as: "text",
+            policy: { maxBytes: DEFAULT_IMPORT_MAX_BYTES },
+          }
+    );
 
     if (!result.ok) {
       setFileError(result.error);
@@ -122,11 +145,11 @@ export default function Base64Tool() {
     }
 
     if (result.decision.status === "warn") {
-      setFileNotice(
-        `${file.name} is ${formatBytes(result.file.size)}. Large files may take longer to decode.`
-      );
+      setFileNotice(formatBase64FileNotice(result.file, mode(), workflow()));
     }
 
+    setLoadedFile(result.file);
+    setLoadedFileBytes(null);
     setInput(result.value);
   }
 
@@ -145,18 +168,6 @@ export default function Base64Tool() {
     return `${error.file.name} could not be read. ${error.message}.`;
   };
 
-  const tabStyle = (active: boolean) => ({
-    padding: "0.375rem 1rem",
-    "border-radius": "0.375rem",
-    "font-size": "0.8125rem",
-    "font-weight": "600",
-    cursor: "pointer",
-    border: "none",
-    background: active ? "var(--accent-primary)" : "transparent",
-    color: active ? "var(--bg-primary)" : "var(--text-secondary)",
-    transition: "background 0.15s, color 0.15s",
-  });
-
   return (
     <div
       style={{
@@ -172,13 +183,7 @@ export default function Base64Tool() {
       {/* ------------------------------------------------------------------ */}
       {/* Mode toggle + swap                                                  */}
       {/* ------------------------------------------------------------------ */}
-      <div
-        style={{
-          display: "flex",
-          "align-items": "center",
-          gap: "0.5rem",
-        }}
-      >
+      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "0.5rem", "align-items": "center" }}>
         <div
           style={{
             display: "flex",
@@ -190,30 +195,66 @@ export default function Base64Tool() {
             "border-radius": "0.5rem",
           }}
         >
-          <button style={tabStyle(mode() === "encode")} onClick={() => setMode("encode")}>
+          <ToolActionButton
+            active={mode() === "encode"}
+            variant={mode() === "encode" ? "primary" : "ghost"}
+            onClick={() => handleModeChange("encode")}
+          >
             Encode
-          </button>
-          <button style={tabStyle(mode() === "decode")} onClick={() => setMode("decode")}>
+          </ToolActionButton>
+          <ToolActionButton
+            active={mode() === "decode"}
+            variant={mode() === "decode" ? "primary" : "ghost"}
+            onClick={() => handleModeChange("decode")}
+          >
             Decode
-          </button>
+          </ToolActionButton>
         </div>
 
-        <button
-          onClick={swap}
-          title="Swap input/output"
-          style={{
-            "margin-left": "auto",
-            padding: "0.375rem 0.75rem",
-            "border-radius": "0.375rem",
-            border: "1px solid var(--border)",
-            background: "var(--bg-secondary)",
-            color: "var(--text-secondary)",
-            "font-size": "0.8125rem",
-            cursor: "pointer",
-          }}
+        <div style={{ display: "flex", gap: "0.25rem", "align-items": "center" }}>
+          <ToolActionButton
+            active={variant() === "standard"}
+            variant={variant() === "standard" ? "primary" : "ghost"}
+            onClick={() => setVariant("standard")}
+          >
+            Base64
+          </ToolActionButton>
+          <ToolActionButton
+            active={variant() === "url"}
+            variant={variant() === "url" ? "primary" : "ghost"}
+            onClick={() => setVariant("url")}
+          >
+            Base64url
+          </ToolActionButton>
+        </div>
+
+        <div style={{ display: "flex", gap: "0.25rem", "align-items": "center" }}>
+          <ToolActionButton
+            active={workflow() === "text"}
+            variant={workflow() === "text" ? "primary" : "ghost"}
+            onClick={() => handleWorkflowChange("text")}
+          >
+            Text
+          </ToolActionButton>
+          <ToolActionButton
+            active={workflow() === "file"}
+            variant={workflow() === "file" ? "primary" : "ghost"}
+            onClick={() => handleWorkflowChange("file")}
+          >
+            File / binary
+          </ToolActionButton>
+        </div>
+
+        <div
+          style={{ display: "flex", gap: "0.5rem", "align-items": "center", "margin-left": "auto" }}
         >
-          ⇅ Swap
-        </button>
+          <ToolActionButton onClick={swap} title="Swap input/output">
+            ⇅ Swap
+          </ToolActionButton>
+          <ToolActionButton onClick={reset} variant="ghost">
+            Reset
+          </ToolActionButton>
+        </div>
       </div>
 
       {/* ------------------------------------------------------------------ */}
@@ -229,7 +270,13 @@ export default function Base64Tool() {
             color: "var(--text-secondary)",
           }}
         >
-          {mode() === "encode" ? "Plain text" : "Base64"}
+          {mode() === "encode"
+            ? workflow() === "text"
+              ? "Plain text"
+              : "Binary file"
+            : variant() === "url"
+              ? "Base64url"
+              : "Base64"}
         </label>
 
         {/* Drop zone wrapper */}
@@ -239,19 +286,26 @@ export default function Base64Tool() {
           style={{ position: "relative" }}
         >
           <textarea
-            value={input()}
+            value={mode() === "encode" && workflow() === "file" ? fileSummary() : input()}
             onInput={(e) => {
               setFileError(null);
               setFileNotice(null);
+              setLoadedFile(null);
+              setLoadedFileBytes(null);
               setInput(e.currentTarget.value);
             }}
             placeholder={
               mode() === "encode"
-                ? "Type or paste text to encode, or drop a file…"
-                : "Paste base64 to decode, or drop a file…"
+                ? workflow() === "text"
+                  ? "Type or paste text to encode, or drop a file…"
+                  : "Drop or open a file to encode it as Base64…"
+                : workflow() === "file"
+                  ? "Paste Base64 to inspect as bytes, or drop an encoded file…"
+                  : "Paste Base64 to decode as UTF-8 text, or drop a file…"
             }
             rows={8}
             spellcheck={false}
+            readOnly={mode() === "encode" && workflow() === "file"}
             style={{
               width: "100%",
               padding: "0.875rem 1rem",
@@ -290,7 +344,7 @@ export default function Base64Tool() {
             />
           </label>
           <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>
-            · max {formatBytes(DEFAULT_IMPORT_MAX_BYTES)}
+            Local-only input handling with explicit text and file workflows
           </span>
         </div>
       </div>
@@ -299,69 +353,24 @@ export default function Base64Tool() {
       {/* Error banner                                                        */}
       {/* ------------------------------------------------------------------ */}
       <Show when={fileNotice()}>
-        <div
-          style={{
-            padding: "0.75rem 1rem",
-            "border-radius": "0.5rem",
-            border: "1px solid color-mix(in srgb, var(--accent-warning) 60%, transparent)",
-            background: "color-mix(in srgb, var(--accent-warning) 12%, transparent)",
-            color: "var(--accent-warning)",
-            "font-size": "0.875rem",
-          }}
-        >
-          {fileNotice()}
-        </div>
+        <ToolStatusMessage tone="warning">{fileNotice()}</ToolStatusMessage>
       </Show>
       <Show when={fileError()?.code === "file-too-large"}>
-        <div
-          role="alert"
-          style={{
-            padding: "0.75rem 1rem",
-            "border-radius": "0.5rem",
-            border: "1px solid var(--accent-error)",
-            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
-            color: "var(--accent-error)",
-            "font-size": "0.875rem",
-          }}
-        >
-          File is too large — maximum supported size is {formatBytes(DEFAULT_IMPORT_MAX_BYTES)}.
-        </div>
+        <ToolStatusMessage tone="error">
+          {formatBase64FileTooLargeMessage(DEFAULT_IMPORT_MAX_BYTES)}
+        </ToolStatusMessage>
       </Show>
       <Show when={fileError()?.code === "read-failed"}>
-        <div
-          role="alert"
-          style={{
-            padding: "0.75rem 1rem",
-            "border-radius": "0.5rem",
-            border: "1px solid var(--accent-error)",
-            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
-            color: "var(--accent-error)",
-            "font-size": "0.875rem",
-          }}
-        >
-          {fileReadErrorMessage()}
-        </div>
+        <ToolStatusMessage tone="error">{fileReadErrorMessage()}</ToolStatusMessage>
       </Show>
-      <Show when={result().error}>
-        <div
-          role="alert"
-          style={{
-            padding: "0.75rem 1rem",
-            "border-radius": "0.5rem",
-            border: "1px solid var(--accent-error)",
-            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
-            color: "var(--accent-error)",
-            "font-size": "0.875rem",
-          }}
-        >
-          {result().error}
-        </div>
+      <Show when={transformError()}>
+        <ToolStatusMessage tone="error">{transformError()}</ToolStatusMessage>
       </Show>
 
       {/* ------------------------------------------------------------------ */}
       {/* Output                                                              */}
       {/* ------------------------------------------------------------------ */}
-      <Show when={result().value}>
+      <Show when={outputValue()}>
         {(value) => (
           <div
             style={{
@@ -390,7 +399,13 @@ export default function Base64Tool() {
                   color: "var(--text-secondary)",
                 }}
               >
-                {mode() === "encode" ? "Base64" : "Plain text"}
+                {mode() === "encode"
+                  ? variant() === "url"
+                    ? "Base64url"
+                    : "Base64"
+                  : workflow() === "file"
+                    ? "Decoded bytes"
+                    : "Decoded text"}
               </span>
               <CopyButton text={value()} />
             </div>
@@ -413,6 +428,15 @@ export default function Base64Tool() {
             </pre>
           </div>
         )}
+      </Show>
+
+      <Show
+        when={!input().trim() && !fileSummary() && !fileNotice() && !fileError() && !outputValue()}
+      >
+        <ToolStatusMessage tone="muted">
+          Standard Base64 and Base64url are both supported. File workflows stay local and surface
+          large-input warnings instead of failing silently.
+        </ToolStatusMessage>
       </Show>
     </div>
   );

--- a/src/tools/regex-tester/RegexTester.tsx
+++ b/src/tools/regex-tester/RegexTester.tsx
@@ -1,7 +1,14 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
-import { buildRegexResult, type FlagKey, type MatchResult } from "@/lib/regex";
+import ToolActionButton from "@/components/ToolActionButton";
+import ToolStatusMessage from "@/components/ToolStatusMessage";
+import {
+  buildRegexReplaceResult,
+  buildRegexResult,
+  type FlagKey,
+  type MatchResult,
+} from "@/lib/regex";
 
 interface Flag {
   key: FlagKey;
@@ -16,10 +23,14 @@ const ALL_FLAGS: Flag[] = [
   { key: "s", label: "s", title: "Dot-all — . matches newlines" },
 ];
 
+type RegexMode = "match" | "replace";
+
 export default function RegexTester() {
+  const [mode, setMode] = createSignal<RegexMode>("match");
   const [pattern, setPattern] = createSignal("");
   const [flags, setFlags] = createSignal<Set<FlagKey>>(new Set(["g"]));
   const [input, setInput] = createSignal("");
+  const [replacement, setReplacement] = createSignal("");
 
   function toggleFlag(key: FlagKey) {
     setFlags((prev) => {
@@ -35,6 +46,17 @@ export default function RegexTester() {
 
   const result = createMemo(() => buildRegexResult(pattern(), flags(), input()));
   const matchCount = createMemo(() => result().matches.length);
+  const replaceResult = createMemo(() =>
+    buildRegexReplaceResult(pattern(), flags(), input(), replacement())
+  );
+  const replaceOutput = createMemo(() => {
+    const current = replaceResult();
+    return "error" in current ? "" : current.output;
+  });
+  const replaceCount = createMemo(() => {
+    const current = replaceResult();
+    return "error" in current ? 0 : current.replacements;
+  });
 
   const namedGroupNames = createMemo((): string[] => {
     const names = new Set<string>();
@@ -69,6 +91,23 @@ export default function RegexTester() {
       }}
     >
       <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
+        <div style={{ display: "flex", gap: "0.5rem", "flex-wrap": "wrap" }}>
+          <ToolActionButton
+            active={mode() === "match"}
+            variant={mode() === "match" ? "primary" : "ghost"}
+            onClick={() => setMode("match")}
+          >
+            Match
+          </ToolActionButton>
+          <ToolActionButton
+            active={mode() === "replace"}
+            variant={mode() === "replace" ? "primary" : "ghost"}
+            onClick={() => setMode("replace")}
+          >
+            Replace
+          </ToolActionButton>
+        </div>
+
         <label style={labelStyle}>Pattern</label>
         <div
           style={{
@@ -159,20 +198,14 @@ export default function RegexTester() {
 
       <Show when={result().error}>
         {(msg) => (
-          <div
-            role="alert"
+          <ToolStatusMessage
+            tone="error"
             style={{
-              padding: "0.75rem 1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--accent-error)",
-              background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
-              color: "var(--accent-error)",
-              "font-size": "0.875rem",
               "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
             }}
           >
             {msg()}
-          </div>
+          </ToolStatusMessage>
         )}
       </Show>
 
@@ -201,6 +234,59 @@ export default function RegexTester() {
         />
       </div>
 
+      <Show when={mode() === "replace"}>
+        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
+          <label style={labelStyle}>Replacement</label>
+          <input
+            type="text"
+            value={replacement()}
+            onInput={(e) => setReplacement(e.currentTarget.value)}
+            placeholder="Replacement text"
+            spellcheck={false}
+            style={{
+              width: "100%",
+              padding: "0.875rem 1rem",
+              "border-radius": "0.5rem",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "font-size": "0.875rem",
+              outline: "none",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+      </Show>
+
+      <Show when={pattern() && !result().error}>
+        <div style={{ display: "flex", gap: "0.75rem", "flex-wrap": "wrap" }}>
+          <ToolStatusMessage
+            tone={matchCount() > 0 ? "success" : "muted"}
+            style={{ padding: "0.625rem 0.875rem" }}
+          >
+            {matchCount() === 0
+              ? "No matches"
+              : `${matchCount()} ${matchCount() === 1 ? "match" : "matches"}`}
+          </ToolStatusMessage>
+          <ToolStatusMessage tone="muted" style={{ padding: "0.625rem 0.875rem" }}>
+            {result().summary.captureGroupCount} capture{" "}
+            {result().summary.captureGroupCount === 1 ? "group" : "groups"}
+          </ToolStatusMessage>
+          <Show when={result().summary.emptyMatchCount > 0}>
+            <ToolStatusMessage tone="warning" style={{ padding: "0.625rem 0.875rem" }}>
+              {result().summary.emptyMatchCount} empty
+              {result().summary.emptyMatchCount === 1 ? " match" : " matches"}
+            </ToolStatusMessage>
+          </Show>
+          <Show when={result().summary.firstMatchIndex !== null}>
+            <ToolStatusMessage tone="muted" style={{ padding: "0.625rem 0.875rem" }}>
+              First match at index {result().summary.firstMatchIndex}
+            </ToolStatusMessage>
+          </Show>
+        </div>
+      </Show>
+
       <Show when={input().trim()}>
         <div
           style={{
@@ -219,7 +305,7 @@ export default function RegexTester() {
               "border-bottom": "1px solid var(--border)",
             }}
           >
-            <span style={labelStyle}>Matches</span>
+            <span style={labelStyle}>{mode() === "replace" ? "Match preview" : "Matches"}</span>
             <Show
               when={pattern() && !result().error}
               fallback={
@@ -233,11 +319,13 @@ export default function RegexTester() {
                   color: matchCount() > 0 ? "var(--accent-success)" : "var(--text-muted)",
                 }}
               >
-                {matchCount() === 0
-                  ? "No matches"
-                  : matchCount() === 1
-                    ? "1 match"
-                    : `${matchCount()} matches`}
+                {mode() === "replace"
+                  ? `${replaceCount()} ${replaceCount() === 1 ? "replacement" : "replacements"}`
+                  : matchCount() === 0
+                    ? "No matches"
+                    : matchCount() === 1
+                      ? "1 match"
+                      : `${matchCount()} matches`}
               </span>
             </Show>
           </div>
@@ -256,6 +344,50 @@ export default function RegexTester() {
             }}
             innerHTML={result().highlighted}
           />
+        </div>
+      </Show>
+
+      <Show
+        when={
+          mode() === "replace" && input().trim() && !result().error && !("error" in replaceResult())
+        }
+      >
+        <div
+          style={{
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            "border-radius": "0.5rem",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              "align-items": "center",
+              "justify-content": "space-between",
+              padding: "0.5rem 1rem",
+              "border-bottom": "1px solid var(--border)",
+            }}
+          >
+            <span style={labelStyle}>Replaced output</span>
+            <CopyButton text={replaceOutput()} />
+          </div>
+
+          <pre
+            style={{
+              margin: "0",
+              padding: "1rem",
+              "overflow-x": "auto",
+              "font-size": "0.875rem",
+              "line-height": "1.8",
+              color: "var(--text-primary)",
+              "font-family": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              "white-space": "pre-wrap",
+              "word-break": "break-all",
+            }}
+          >
+            {replaceOutput()}
+          </pre>
         </div>
       </Show>
 
@@ -419,9 +551,9 @@ export default function RegexTester() {
       </Show>
 
       <Show when={!pattern() && !input().trim()}>
-        <p style={{ "font-size": "0.8125rem", color: "var(--text-muted)", margin: "0" }}>
-          Enter a regex pattern and test string — matches are highlighted in real time
-        </p>
+        <ToolStatusMessage tone="muted">
+          Enter a regex pattern and test string to inspect matches or preview replacements locally.
+        </ToolStatusMessage>
       </Show>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a shared Base64 transform library with direct tests and upgrade the Base64 tool with Base64url support plus explicit text and file workflows
- make Base64 invalid-input and large-input states clearer while keeping copy semantics aligned with the shared tool baseline
- add regex replace mode, richer match summaries, and direct regex transform tests outside the component

Closes #83
Closes #84

## Verification
- bun run type-check
- bun run lint
- bun run test
- bun run build
- bun run format:check

## Preview Validation
- Base64: verify standard Base64 encode and decode with text input, then switch to Base64url and confirm URL-safe output and decoding still work
- Base64: switch between text and file workflows, drop or open a file to encode it, and confirm large-input warnings and invalid-input errors remain explicit and recoverable
- Regex: verify match mode still highlights matches and capture groups, including named groups and zero-match states
- Regex: switch to replace mode, confirm replaced output updates locally, copy the replaced output, and verify invalid-pattern handling still remains understandable