### PR TITLE
chore: standardize workspace setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Twish Dev Environment",
+  "name": "Unwrapped Dev Environment",
   "build": {
     "dockerfile": "Dockerfile"
   },
@@ -10,6 +10,7 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "bradlc.vscode-tailwindcss",
+        "editorconfig.editorconfig",
         "unifiedjs.vscode-mdx",
         "christian-kohler.path-intellisense",
         "formulahendry.auto-rename-tag",

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ Thumbs.db
 
 # Editor directories
 .idea/
+.vscode/*
+!.vscode/extensions.json
 *.suo
 *.ntvs*
 *.njsproj

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "astro-build.astro-vscode",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss",
+    "editorconfig.editorconfig",
+    "unifiedjs.vscode-mdx",
+    "christian-kohler.path-intellisense",
+    "formulahendry.auto-rename-tag",
+    "streetsidesoftware.code-spell-checker",
+    "vitest.explorer"
+  ],
+  "unwantedRecommendations": []
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "unwrapped-tools",
   "type": "module",
+  "packageManager": "bun@1.3.5",
   "version": "1.0.0",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- align the shared devcontainer workspace recommendations with the phase 1 baseline and keep the container metadata consistent
- standardize committed editor setup by keeping only `.vscode/extensions.json` and removing repo-level VS Code settings or launch config
- normalize Bun package manager metadata so local tooling setup is consistent with the pinned workspace runtime

## Verification
- bun run verify