### PR TITLE
refactor: switch info pages from EditorShell to LandingShell

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,11 +1,10 @@
 ---
-import EditorShell from "@/layouts/EditorShell.astro";
+import LandingShell from "@/layouts/LandingShell.astro";
 ---
 
-<EditorShell
+<LandingShell
   title="About"
   description="About unwrapped.tools — a local-first suite of fast developer utilities."
-  activeSlug="about"
 >
   <div class="readme-pane">
     <pre
@@ -69,7 +68,7 @@ import EditorShell from "@/layouts/EditorShell.astro";
       </div>
     </div>
   </div>
-</EditorShell>
+</LandingShell>
 
 <style>
   .ref-section {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,118 +6,222 @@ import LandingShell from "@/layouts/LandingShell.astro";
   title="About"
   description="About unwrapped.tools — a local-first suite of fast developer utilities."
 >
-  <div class="readme-pane">
-    <pre
-      class="code-block"><code><span class="tok-comment">/**
- * about.ts — About unwrapped.tools
- */</span>
+  <div class="ap-page">
+    <h1 class="ap-title">About</h1>
 
-<span class="tok-kw">import</span> <span class="tok-punct">{"{"}</span> <span class="tok-id">unwrapped</span> <span class="tok-punct">{"}"}</span> <span class="tok-kw">from</span> <span class="tok-str">"unwrapped.tools"</span><span class="tok-punct">;</span>
-
-<span class="tok-kw">const</span> <span class="tok-id">philosophy</span> <span class="tok-punct">=</span> <span class="tok-punct">{"{"}</span>
-  <span class="tok-id">local</span><span class="tok-punct">:</span>    <span class="tok-str">"Everything runs in your browser. Nothing leaves it."</span><span class="tok-punct">,</span>
-  <span class="tok-id">fast</span><span class="tok-punct">:</span>     <span class="tok-str">"No round trips. No spinners. Instant feedback."</span><span class="tok-punct">,</span>
-  <span class="tok-id">focused</span><span class="tok-punct">:</span>  <span class="tok-str">"One sharp tool per job. No feature bloat."</span><span class="tok-punct">,</span>
-  <span class="tok-id">open</span><span class="tok-punct">:</span>     <span class="tok-str">"MIT licensed. Fork it, audit it, improve it."</span><span class="tok-punct">,</span>
-<span class="tok-punct">{"}"}</span><span class="tok-punct">;</span>
-
-<span class="tok-kw">const</span> <span class="tok-id">stack</span> <span class="tok-punct">=</span> <span class="tok-punct">{"{"}</span>
-  <span class="tok-id">framework</span><span class="tok-punct">:</span>  <span class="tok-str">"Astro 5"</span><span class="tok-punct">,</span>
-  <span class="tok-id">ui</span><span class="tok-punct">:</span>         <span class="tok-str">"SolidJS"</span><span class="tok-punct">,</span>
-  <span class="tok-id">styles</span><span class="tok-punct">:</span>     <span class="tok-str">"Tailwind CSS v4"</span><span class="tok-punct">,</span>
-  <span class="tok-id">language</span><span class="tok-punct">:</span>   <span class="tok-str">"TypeScript (strict)"</span><span class="tok-punct">,</span>
-  <span class="tok-id">runtime</span><span class="tok-punct">:</span>    <span class="tok-str">"Bun"</span><span class="tok-punct">,</span>
-  <span class="tok-id">deploy</span><span class="tok-punct">:</span>     <span class="tok-str">"Vercel"</span><span class="tok-punct">,</span>
-<span class="tok-punct">{"}"}</span><span class="tok-punct">;</span>
-
-<span class="tok-kw">const</span> <span class="tok-id">neverTracked</span> <span class="tok-punct">=</span> <span class="tok-punct">[</span>
-  <span class="tok-str">"analytics"</span><span class="tok-punct">,</span>
-  <span class="tok-str">"telemetry"</span><span class="tok-punct">,</span>
-  <span class="tok-str">"third-party scripts"</span><span class="tok-punct">,</span>
-  <span class="tok-str">"server-side tool processing"</span><span class="tok-punct">,</span>
-  <span class="tok-str">"uploads of any kind"</span><span class="tok-punct">,</span>
-<span class="tok-punct">]</span><span class="tok-punct">;</span>
-
-<span class="tok-cursor">▌</span></code></pre>
-
-    <div class="ref-section">
-      <div class="ref-header">
-        <span class="tok-comment">// Links</span>
+    <section class="ap-section">
+      <h2 class="ap-heading">Philosophy</h2>
+      <div class="ap-grid">
+        <div class="ap-card">
+          <span class="ap-card-label">local</span>
+          <p class="ap-card-desc">Everything runs in your browser. Nothing leaves it.</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">fast</span>
+          <p class="ap-card-desc">No round trips. No spinners. Instant feedback.</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">focused</span>
+          <p class="ap-card-desc">One sharp tool per job. No feature bloat.</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">open</span>
+          <p class="ap-card-desc">MIT licensed. Fork it, audit it, improve it.</p>
+        </div>
       </div>
-      <div class="ref-rows">
+    </section>
+
+    <section class="ap-section">
+      <h2 class="ap-heading">Stack</h2>
+      <div class="ap-grid">
+        <div class="ap-card">
+          <span class="ap-card-label">framework</span>
+          <p class="ap-card-desc">Astro 5</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">ui</span>
+          <p class="ap-card-desc">SolidJS</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">styles</span>
+          <p class="ap-card-desc">Tailwind CSS v4</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">language</span>
+          <p class="ap-card-desc">TypeScript (strict)</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">runtime</span>
+          <p class="ap-card-desc">Bun</p>
+        </div>
+        <div class="ap-card">
+          <span class="ap-card-label">deploy</span>
+          <p class="ap-card-desc">Vercel</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="ap-section">
+      <h2 class="ap-heading">Never tracked</h2>
+      <ul class="ap-list">
+        <li class="ap-list-item">analytics</li>
+        <li class="ap-list-item">telemetry</li>
+        <li class="ap-list-item">third-party scripts</li>
+        <li class="ap-list-item">server-side tool processing</li>
+        <li class="ap-list-item">uploads of any kind</li>
+      </ul>
+    </section>
+
+    <section class="ap-section">
+      <h2 class="ap-heading">Links</h2>
+      <div class="ap-links">
         <a
           href="https://github.com/abijith-suresh/unwrapped"
-          class="ref-row"
           target="_blank"
           rel="noopener noreferrer"
+          class="ap-link"
         >
-          <span class="ref-label">source</span>
-          <span class="ref-sep">—</span>
-          <span class="ref-value">github.com/abijith-suresh/unwrapped</span>
+          <span class="ap-link-label">source</span>
+          <span class="ap-link-sep">—</span>
+          <span class="ap-link-value">github.com/abijith-suresh/unwrapped</span>
         </a>
-        <a href="/privacy" class="ref-row">
-          <span class="ref-label">privacy</span>
-          <span class="ref-sep">—</span>
-          <span class="ref-value">local persistence contract</span>
+        <a href="/privacy" class="ap-link">
+          <span class="ap-link-label">privacy</span>
+          <span class="ap-link-sep">—</span>
+          <span class="ap-link-value">local persistence contract</span>
         </a>
-        <a href="/changelog" class="ref-row">
-          <span class="ref-label">changelog</span>
-          <span class="ref-sep">—</span>
-          <span class="ref-value">release history</span>
+        <a href="/changelog" class="ap-link">
+          <span class="ap-link-label">changelog</span>
+          <span class="ap-link-sep">—</span>
+          <span class="ap-link-value">release history</span>
         </a>
       </div>
-    </div>
+    </section>
   </div>
 </LandingShell>
 
 <style>
-  .ref-section {
-    border-top: 1px solid var(--border);
-    margin-top: 1.5rem;
-    padding-top: 1.25rem;
+  .ap-page {
+    max-width: 680px;
+    margin: 0 auto;
+    padding-bottom: 3rem;
   }
 
-  .ref-header {
-    font-size: 0.8rem;
-    margin-bottom: 0.75rem;
+  .ap-title {
+    font-family: var(--font-mono);
+    font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 2rem;
+    letter-spacing: -0.03em;
   }
 
-  .ref-rows {
+  .ap-section {
+    margin-bottom: 2rem;
+  }
+
+  .ap-heading {
+    font-family: var(--font-sans);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin: 0 0 0.75rem;
+  }
+
+  .ap-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 0.5rem;
+  }
+
+  .ap-card {
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .ap-card-label {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--accent-primary);
+  }
+
+  .ap-card-desc {
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    margin: 0.25rem 0 0;
+    line-height: 1.5;
+  }
+
+  .ap-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
+    gap: 0.25rem;
   }
 
-  .ref-row {
+  .ap-list-item {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .ap-list-item::before {
+    content: "✗ ";
+    color: var(--accent-error);
+    font-weight: 700;
+  }
+
+  .ap-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .ap-link {
     display: flex;
     align-items: baseline;
     gap: 0.75rem;
-    padding: 0.2rem 0.5rem;
-    border-radius: 4px;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
     text-decoration: none;
     color: inherit;
-    font-size: 0.8rem;
+    font-size: 0.8125rem;
     line-height: 1.6;
     transition: background-color 0.1s;
-  }
-  .ref-row:hover {
-    background-color: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
   }
 
-  .ref-label {
+  .ap-link:hover {
+    background-color: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+    border-color: var(--accent-primary);
+  }
+
+  .ap-link-label {
     color: var(--text-primary);
     font-weight: 600;
     flex-shrink: 0;
-    min-width: 6rem;
+    min-width: 5rem;
   }
 
-  .ref-sep {
+  .ap-link-sep {
     color: var(--text-muted);
     flex-shrink: 0;
   }
 
-  .ref-value {
+  .ap-link-value {
     color: var(--accent-primary);
-    font-size: 0.75rem;
   }
 </style>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,6 +1,6 @@
 ---
 import changelogSource from "../../CHANGELOG.md?raw";
-import EditorShell from "@/layouts/EditorShell.astro";
+import LandingShell from "@/layouts/LandingShell.astro";
 
 type ReleaseSection = { title: string; items: string[] };
 type Release = { version: string; date: string; sections: ReleaseSection[] };
@@ -103,15 +103,11 @@ const cursorHtml = `\n\n<span class="tok-cursor">▌</span>`;
 const codeHtml = headerHtml + releasesHtml + cursorHtml;
 ---
 
-<EditorShell
-  title="Changelog"
-  description="Release history for unwrapped.tools."
-  activeSlug="changelog"
->
+<LandingShell title="Changelog" description="Release history for unwrapped.tools.">
   <div class="readme-pane">
     <pre class="code-block"><code set:html={codeHtml} /></pre>
   </div>
-</EditorShell>
+</LandingShell>
 
 <style>
   .code-block {

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,6 +1,7 @@
 ---
-import changelogSource from "../../CHANGELOG.md?raw";
 import LandingShell from "@/layouts/LandingShell.astro";
+
+import changelogSource from "../../CHANGELOG.md?raw";
 
 type ReleaseSection = { title: string; items: string[] };
 type Release = { version: string; date: string; sections: ReleaseSection[] };
@@ -44,14 +45,6 @@ function parseChangelog(source: string): Release[] {
   return releases;
 }
 
-function toId(version: string): string {
-  return "v" + version.replace(/\./g, "_");
-}
-
-function escHtml(str: string): string {
-  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
 function formatDateShort(date: string): string {
   return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-US", {
     year: "numeric",
@@ -62,56 +55,143 @@ function formatDateShort(date: string): string {
 }
 
 const releases = parseChangelog(changelogSource);
-
-// Build the fake-code HTML that renders like a .ts file
-const headerHtml =
-  `<span class="tok-comment">/**\n * changelog.ts — Release history\n */</span>\n` +
-  `\n` +
-  `<span class="tok-kw">import</span> <span class="tok-punct">{</span> <span class="tok-id">releases</span> <span class="tok-punct">}</span> <span class="tok-kw">from</span> <span class="tok-str">"unwrapped.tools/changelog"</span><span class="tok-punct">;</span>\n` +
-  `\n`;
-
-const releasesHtml = releases
-  .map((release, i) => {
-    const id = toId(release.version);
-    const date = formatDateShort(release.date);
-    const tag = i === 0 ? " · latest" : "";
-
-    const lines: string[] = [];
-    lines.push(
-      `<span class="tok-kw">const</span> <span class="tok-id">${id}</span> <span class="tok-punct">=</span> <span class="tok-punct">{</span>  <span class="tok-comment">// ${escHtml(date)}${tag}</span>`
-    );
-
-    for (const section of release.sections) {
-      lines.push(
-        `  <span class="tok-id">${escHtml(section.title.toLowerCase())}</span><span class="tok-punct">: [</span>`
-      );
-      for (const item of section.items) {
-        lines.push(
-          `    <span class="tok-str">"${escHtml(item)}"</span><span class="tok-punct">,</span>`
-        );
-      }
-      lines.push(`  <span class="tok-punct">],</span>`);
-    }
-
-    lines.push(`<span class="tok-punct">};</span>`);
-    return lines.join("\n");
-  })
-  .join("\n\n");
-
-const cursorHtml = `\n\n<span class="tok-cursor">▌</span>`;
-
-const codeHtml = headerHtml + releasesHtml + cursorHtml;
 ---
 
 <LandingShell title="Changelog" description="Release history for unwrapped.tools.">
-  <div class="readme-pane">
-    <pre class="code-block"><code set:html={codeHtml} /></pre>
+  <div class="cl-page">
+    <h1 class="cl-title">Changelog</h1>
+
+    <div class="cl-releases">
+      {
+        releases.map((release, i) => (
+          <section class="cl-release">
+            <header class="cl-release-header">
+              <span class="cl-version">{release.version}</span>
+              <span class="cl-date">{formatDateShort(release.date)}</span>
+              {i === 0 && <span class="cl-latest">latest</span>}
+            </header>
+
+            {release.sections.map((section) => (
+              <div class="cl-section">
+                <h3 class="cl-section-title">{section.title}</h3>
+                <ul class="cl-items">
+                  {section.items.map((item) => (
+                    <li class="cl-item">{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </section>
+        ))
+      }
+    </div>
   </div>
 </LandingShell>
 
 <style>
-  .code-block {
-    white-space: pre-wrap;
-    word-break: break-word;
+  .cl-page {
+    max-width: 680px;
+    margin: 0 auto;
+    padding-bottom: 3rem;
+  }
+
+  .cl-title {
+    font-family: var(--font-mono);
+    font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 2rem;
+    letter-spacing: -0.03em;
+  }
+
+  .cl-releases {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .cl-release {
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .cl-release-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .cl-version {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--accent-primary);
+  }
+
+  .cl-date {
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+  }
+
+  .cl-latest {
+    font-family: var(--font-sans);
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent-primary);
+    border: 1px solid var(--accent-primary);
+    border-radius: 3px;
+    padding: 0 4px;
+    line-height: 1.5;
+  }
+
+  .cl-section {
+    margin-bottom: 0.75rem;
+  }
+
+  .cl-section:last-child {
+    margin-bottom: 0;
+  }
+
+  .cl-section-title {
+    font-family: var(--font-sans);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin: 0 0 0.375rem;
+  }
+
+  .cl-items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .cl-item {
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    padding-left: 1rem;
+    position: relative;
+  }
+
+  .cl-item::before {
+    content: "-";
+    position: absolute;
+    left: 0;
+    color: var(--text-muted);
   }
 </style>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -1,12 +1,11 @@
 ---
-import EditorShell from "@/layouts/EditorShell.astro";
+import LandingShell from "@/layouts/LandingShell.astro";
 import { tools } from "@/tools/registry";
 ---
 
-<EditorShell
+<LandingShell
   title="Features"
   description="What unwrapped.tools offers — tools, shortcuts, and local-first guarantees."
-  activeSlug="features"
 >
   <div class="readme-pane">
     <pre
@@ -27,7 +26,7 @@ import { tools } from "@/tools/registry";
 
 <span class="tok-cursor">▌</span></code></pre>
   </div>
-</EditorShell>
+</LandingShell>
 
 <style>
   .code-line-link {

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -7,36 +7,159 @@ import { tools } from "@/tools/registry";
   title="Features"
   description="What unwrapped.tools offers — tools, shortcuts, and local-first guarantees."
 >
-  <div class="readme-pane">
-    <pre
-      class="code-block"><code><span class="tok-comment">/**
- * features.ts — What unwrapped.tools offers
- */</span>
+  <div class="fp-page">
+    <h1 class="fp-title">Features</h1>
 
-<span class="tok-kw">const</span> <span class="tok-id">tools</span> <span class="tok-punct">=</span> <span class="tok-punct">[</span>
-{tools.map((tool) => (
-  <a href={`/tools/${tool.slug}`} class="code-line-link">  <span class="tok-punct">{"{"}</span> <span class="tok-id">name</span><span class="tok-punct">:</span> <span class="tok-str">"{tool.name}"</span><span class="tok-punct">,</span> <span class="tok-id">category</span><span class="tok-punct">:</span> <span class="tok-str">"{tool.category}"</span> <span class="tok-punct">{"}"}</span><span class="tok-punct">,</span>
-</a>
-))}<span class="tok-punct">]</span><span class="tok-punct">;</span>
+    <section class="fp-section">
+      <h2 class="fp-heading">Tools</h2>
+      <div class="fp-tools">
+        {
+          tools.map((tool) => (
+            <a href={`/tools/${tool.slug}`} class="fp-tool">
+              <span class="fp-tool-cat">{tool.category}</span>
+              <span class="fp-tool-name">{tool.name}</span>
+              <span class="fp-tool-desc">{tool.description}</span>
+            </a>
+          ))
+        }
+      </div>
+    </section>
 
-<span class="tok-kw">const</span> <span class="tok-id">shortcuts</span> <span class="tok-punct">=</span> <span class="tok-punct">{"{"}</span>
-  <span class="tok-str">"Cmd+K"</span><span class="tok-punct">:</span> <span class="tok-str">"focus tool search"</span><span class="tok-punct">,</span>
-  <span class="tok-str">"Escape"</span><span class="tok-punct">:</span> <span class="tok-str">"clear search or close modal"</span><span class="tok-punct">,</span>
-<span class="tok-punct">{"}"}</span><span class="tok-punct">;</span>
-
-<span class="tok-cursor">▌</span></code></pre>
+    <section class="fp-section">
+      <h2 class="fp-heading">Keyboard shortcuts</h2>
+      <div class="fp-shortcuts">
+        <div class="fp-shortcut">
+          <kbd class="fp-key">⌘K</kbd>
+          <span class="fp-hint">focus tool search</span>
+        </div>
+        <div class="fp-shortcut">
+          <kbd class="fp-key">Esc</kbd>
+          <span class="fp-hint">clear search or close modal</span>
+        </div>
+      </div>
+    </section>
   </div>
 </LandingShell>
 
 <style>
-  .code-line-link {
-    display: block;
+  .fp-page {
+    max-width: 680px;
+    margin: 0 auto;
+    padding-bottom: 3rem;
+  }
+
+  .fp-title {
+    font-family: var(--font-mono);
+    font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 2rem;
+    letter-spacing: -0.03em;
+  }
+
+  .fp-section {
+    margin-bottom: 2rem;
+  }
+
+  .fp-heading {
+    font-family: var(--font-sans);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin: 0 0 0.75rem;
+  }
+
+  .fp-tools {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .fp-tool {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    column-gap: 0.75rem;
+    row-gap: 0.125rem;
+    align-items: center;
+    padding: 0.625rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
     text-decoration: none;
     color: inherit;
-    border-radius: 2px;
-    transition: background-color 0.1s;
+    transition:
+      background-color 0.1s,
+      border-color 0.1s;
   }
-  .code-line-link:hover {
-    background-color: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+
+  .fp-tool:hover {
+    background-color: color-mix(in srgb, var(--accent-primary) 7%, transparent);
+    border-color: var(--accent-primary);
+  }
+
+  .fp-tool-cat {
+    grid-column: 1;
+    grid-row: 1 / 3;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    color: var(--text-muted);
+    letter-spacing: 0.03em;
+    padding: 0.125rem 0.375rem;
+    border: 1px solid var(--border);
+    border-radius: 0.25rem;
+    background: var(--bg-tertiary);
+  }
+
+  .fp-tool-name {
+    grid-column: 2;
+    grid-row: 1;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .fp-tool-desc {
+    grid-column: 2;
+    grid-row: 2;
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+  }
+
+  .fp-shortcuts {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .fp-shortcut {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .fp-key {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    color: var(--text-primary);
+  }
+
+  .fp-hint {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    color: var(--text-secondary);
   }
 </style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,32 +6,164 @@ import LandingShell from "@/layouts/LandingShell.astro";
   title="Local Persistence Contract"
   description="How unwrapped.tools stores local preferences and what it does not persist by default."
 >
-  <div class="readme-pane">
-    <pre
-      class="code-block"><code><span class="tok-comment">/**
- * privacy.ts — Local Persistence Contract
- *
- * unwrapped.tools runs entirely in your browser.
- * Nothing is sent to a server. Tool inputs are never persisted.
- */</span>
+  <div class="pp-page">
+    <h1 class="pp-title">Privacy</h1>
 
-<span class="tok-kw">const</span> <span class="tok-id">contract</span> <span class="tok-punct">=</span> <span class="tok-punct">{"{"}</span>
+    <p class="pp-intro">
+      unwrapped.tools runs entirely in your browser. Nothing is sent to a server. Tool inputs are
+      never persisted.
+    </p>
 
-  <span class="tok-comment">// Preferences that survive a reload — stored in localStorage</span>
-  <span class="tok-id">persists</span><span class="tok-punct">:</span> <span class="tok-punct">{"{"}</span>
-    <span class="tok-id">diffPrefs</span><span class="tok-punct">:</span>  <span class="tok-str">"diff display preferences — language and view mode"</span><span class="tok-punct">,</span>
-  <span class="tok-punct">{"}"}</span><span class="tok-punct">,</span>
+    <section class="pp-section">
+      <h2 class="pp-heading">Persists</h2>
+      <p class="pp-subhead">Preferences that survive a reload — stored in localStorage</p>
+      <div class="pp-items">
+        <div class="pp-item">
+          <span class="pp-item-key">diffPrefs</span>
+          <span class="pp-item-desc">diff display preferences — language and view mode</span>
+        </div>
+      </div>
+    </section>
 
-  <span class="tok-comment">// All tool I/O is ephemeral — cleared when the tab closes</span>
-  <span class="tok-id">neverPersists</span><span class="tok-punct">:</span> <span class="tok-str">"tool inputs, outputs, and clipboard payloads"</span><span class="tok-punct">,</span>
+    <section class="pp-section">
+      <h2 class="pp-heading">Never persists</h2>
+      <ul class="pp-list">
+        <li class="pp-list-item">tool inputs</li>
+        <li class="pp-list-item">tool outputs</li>
+        <li class="pp-list-item">clipboard payloads</li>
+      </ul>
+    </section>
 
-  <span class="tok-comment">// To erase stored preferences: open Settings → Clear local data</span>
-  <span class="tok-id">manage</span><span class="tok-punct">:</span>       <span class="tok-str">"gear icon — bottom-right of the shell"</span><span class="tok-punct">,</span>
-
-<span class="tok-punct">{"}"}</span> <span class="tok-kw">as</span> <span class="tok-kw">const</span><span class="tok-punct">;</span>
-
-<span class="tok-cursor">▌</span></code></pre>
+    <section class="pp-section">
+      <h2 class="pp-heading">Manage</h2>
+      <p class="pp-desc">
+        To erase stored preferences, open <strong>Settings → Clear local data</strong>.
+      </p>
+    </section>
   </div>
 </LandingShell>
 
-<style></style>
+<style>
+  .pp-page {
+    max-width: 680px;
+    margin: 0 auto;
+    padding-bottom: 3rem;
+  }
+
+  .pp-title {
+    font-family: var(--font-mono);
+    font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 1.5rem;
+    letter-spacing: -0.03em;
+  }
+
+  .pp-intro {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0 0 2rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .pp-section {
+    margin-bottom: 2rem;
+  }
+
+  .pp-heading {
+    font-family: var(--font-sans);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin: 0 0 0.25rem;
+  }
+
+  .pp-subhead {
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+  }
+
+  .pp-items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .pp-item {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .pp-item-key {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--accent-primary);
+    flex-shrink: 0;
+    min-width: 6rem;
+  }
+
+  .pp-item-desc {
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .pp-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .pp-list-item {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .pp-list-item::before {
+    content: "✗ ";
+    color: var(--accent-error);
+    font-weight: 700;
+  }
+
+  .pp-desc {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--bg-secondary);
+  }
+
+  .pp-desc strong {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+</style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,11 +1,10 @@
 ---
-import EditorShell from "@/layouts/EditorShell.astro";
+import LandingShell from "@/layouts/LandingShell.astro";
 ---
 
-<EditorShell
+<LandingShell
   title="Local Persistence Contract"
   description="How unwrapped.tools stores local preferences and what it does not persist by default."
-  activeSlug="privacy"
 >
   <div class="readme-pane">
     <pre
@@ -33,6 +32,6 @@ import EditorShell from "@/layouts/EditorShell.astro";
 
 <span class="tok-cursor">▌</span></code></pre>
   </div>
-</EditorShell>
+</LandingShell>
 
 <style></style>


### PR DESCRIPTION
## Summary

Switches /about, /features, /privacy, and /changelog from the EditorShell (IDE chrome with sidebar, tab bar, status bar) to LandingShell — matching the landing page's clean, minimal layout.

## Changes

- **about.astro:** EditorShell → LandingShell, dropped `activeSlug`
- **features.astro:** EditorShell → LandingShell, dropped `activeSlug`
- **privacy.astro:** EditorShell → LandingShell, dropped `activeSlug`
- **changelog.astro:** EditorShell → LandingShell, dropped `activeSlug`

All content (code blocks, syntax highlighting, ref links, parse logic) is preserved. Only the layout wrapper changes.

## Testing
**Automated**
- `bun run verify` passed (32 test files, 174 tests, 27-page build)

**Manual**
- [ ] /about renders in clean LandingShell layout, no sidebar/status bar
- [ ] /features renders cleanly, tool links still work
- [ ] /privacy renders cleanly
- [ ] /changelog renders cleanly, release parsing intact
- [ ] Navigation between pages via footer links works