### PR TITLE
feat: add component primitive library and playground page

### DIFF
--- a/src/components/primitives/solid/Badge.tsx
+++ b/src/components/primitives/solid/Badge.tsx
@@ -1,0 +1,35 @@
+import type { JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+type BadgeTone = "muted" | "success" | "warning" | "error";
+
+export interface BadgeProps {
+  tone?: BadgeTone;
+  children?: JSX.Element;
+  class?: string;
+}
+
+const toneStyles: Record<BadgeTone, string> = {
+  muted: "border-[var(--border)] text-[var(--text-muted)] bg-[var(--bg-tertiary)]",
+  success:
+    "border-[var(--accent-success)] text-[var(--accent-success)] bg-[var(--accent-success)]/10",
+  warning:
+    "border-[var(--accent-warning)] text-[var(--accent-warning)] bg-[var(--accent-warning)]/10",
+  error: "border-[var(--accent-error)] text-[var(--accent-error)] bg-[var(--accent-error)]/10",
+};
+
+export default function Badge(props: BadgeProps) {
+  const tone = props.tone ?? "muted";
+
+  return (
+    <span
+      class={cn(
+        "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-semibold",
+        toneStyles[tone],
+        props.class
+      )}
+    >
+      {props.children}
+    </span>
+  );
+}

--- a/src/components/primitives/solid/Button.tsx
+++ b/src/components/primitives/solid/Button.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+type ButtonVariant = "primary" | "secondary" | "ghost";
+type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
+  onClick?: JSX.EventHandlerUnion<HTMLButtonElement, MouseEvent>;
+  type?: JSX.ButtonHTMLAttributes<HTMLButtonElement>["type"];
+  children?: JSX.Element;
+  class?: string;
+}
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    "bg-[var(--accent-primary)] text-[var(--bg-primary)] hover:brightness-110 disabled:opacity-50",
+  secondary:
+    "border border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)] disabled:opacity-50",
+  ghost:
+    "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)] disabled:opacity-50",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+
+export default function Button(props: ButtonProps) {
+  const variant = props.variant ?? "primary";
+  const size = props.size ?? "md";
+
+  return (
+    <button
+      type={props.type ?? "button"}
+      disabled={props.disabled}
+      onClick={props.onClick}
+      class={cn(
+        "inline-flex items-center justify-center rounded-lg font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] cursor-pointer",
+        variantStyles[variant],
+        sizeStyles[size],
+        props.class
+      )}
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/src/components/primitives/solid/Card.tsx
+++ b/src/components/primitives/solid/Card.tsx
@@ -1,0 +1,20 @@
+import type { JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export interface CardProps {
+  children?: JSX.Element;
+  class?: string;
+}
+
+export default function Card(props: CardProps) {
+  return (
+    <div
+      class={cn(
+        "rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] p-4",
+        props.class
+      )}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/src/components/primitives/solid/Input.tsx
+++ b/src/components/primitives/solid/Input.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/cn";
+import Label from "@/components/primitives/solid/Label";
+
+export interface InputProps {
+  label?: string;
+  value?: string;
+  onInput?: (value: string) => void;
+  placeholder?: string;
+  type?: string;
+  class?: string;
+}
+
+export default function Input(props: InputProps) {
+  return (
+    <div class={cn("flex flex-col gap-1.5", props.class)}>
+      {props.label ? <Label>{props.label}</Label> : null}
+      <input
+        type={props.type ?? "text"}
+        value={props.value ?? ""}
+        onInput={(e) => props.onInput?.((e.target as HTMLInputElement).value)}
+        placeholder={props.placeholder}
+        class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono focus:border-[var(--accent-primary)]"
+      />
+    </div>
+  );
+}

--- a/src/components/primitives/solid/Label.tsx
+++ b/src/components/primitives/solid/Label.tsx
@@ -1,0 +1,22 @@
+import type { JSX } from "solid-js";
+import { cn } from "@/lib/cn";
+
+export interface LabelProps {
+  children?: JSX.Element;
+  for?: string;
+  class?: string;
+}
+
+export default function Label(props: LabelProps) {
+  return (
+    <label
+      for={props.for}
+      class={cn(
+        "text-xs font-semibold tracking-wider uppercase text-[var(--text-secondary)]",
+        props.class
+      )}
+    >
+      {props.children}
+    </label>
+  );
+}

--- a/src/components/primitives/solid/PlaygroundApp.tsx
+++ b/src/components/primitives/solid/PlaygroundApp.tsx
@@ -1,0 +1,62 @@
+import { createSignal } from "solid-js";
+import Button from "@/components/primitives/solid/Button";
+import Input from "@/components/primitives/solid/Input";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Select from "@/components/primitives/solid/Select";
+import Badge from "@/components/primitives/solid/Badge";
+import Card from "@/components/primitives/solid/Card";
+
+export default function PlaygroundApp() {
+  const [name, setName] = createSignal("");
+  const [framework, setFramework] = createSignal("astro");
+  const [desc, setDesc] = createSignal("");
+
+  return (
+    <div class="max-w-lg">
+      <Card>
+        <h3 class="text-sm font-semibold text-[var(--text-primary)] mb-4">Interactive Form</h3>
+        <div class="flex flex-col gap-4">
+          <Input label="Name" value={name()} onInput={setName} placeholder="Type something..." />
+          <Select
+            label="Framework"
+            value={framework()}
+            onChange={setFramework}
+            options={[
+              { value: "astro", label: "Astro" },
+              { value: "solid", label: "SolidJS" },
+              { value: "react", label: "React" },
+            ]}
+          />
+          <Textarea
+            label="Description"
+            value={desc()}
+            onInput={setDesc}
+            placeholder="Write something..."
+          />
+          <div class="flex items-center justify-between">
+            <div class="flex gap-2">
+              {framework() === "astro" ? <Badge tone="success">Astro</Badge> : null}
+              {framework() === "solid" ? <Badge tone="warning">Solid</Badge> : null}
+              {framework() === "react" ? <Badge tone="error">React</Badge> : null}
+            </div>
+            <Button
+              variant="primary"
+              onClick={() => {
+                setName("");
+                setFramework("astro");
+                setDesc("");
+              }}
+            >
+              Reset
+            </Button>
+          </div>
+          {name() ? (
+            <p class="text-xs text-[var(--text-muted)]">
+              Hello, <span class="text-[var(--text-primary)]">{name()}</span>!
+            </p>
+          ) : null}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/primitives/solid/Select.tsx
+++ b/src/components/primitives/solid/Select.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/cn";
+import Label from "@/components/primitives/solid/Label";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  label?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  options?: SelectOption[];
+  class?: string;
+}
+
+export default function Select(props: SelectProps) {
+  return (
+    <div class={cn("flex flex-col gap-1.5", props.class)}>
+      {props.label ? <Label>{props.label}</Label> : null}
+      <select
+        value={props.value ?? ""}
+        onChange={(e) => props.onChange?.((e.target as HTMLSelectElement).value)}
+        class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono focus:border-[var(--accent-primary)]"
+      >
+        {props.options?.map((opt) => (
+          <option value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/primitives/solid/Textarea.tsx
+++ b/src/components/primitives/solid/Textarea.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/cn";
+import Label from "@/components/primitives/solid/Label";
+
+export interface TextareaProps {
+  label?: string;
+  value?: string;
+  onInput?: (value: string) => void;
+  placeholder?: string;
+  rows?: number;
+  class?: string;
+}
+
+export default function Textarea(props: TextareaProps) {
+  return (
+    <div class={cn("flex flex-col gap-1.5", props.class)}>
+      {props.label ? <Label>{props.label}</Label> : null}
+      <textarea
+        value={props.value ?? ""}
+        onInput={(e) => props.onInput?.((e.target as HTMLTextAreaElement).value)}
+        placeholder={props.placeholder}
+        rows={props.rows ?? 4}
+        class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono resize-y focus:border-[var(--accent-primary)]"
+      />
+    </div>
+  );
+}

--- a/src/layouts/EditorShell.astro
+++ b/src/layouts/EditorShell.astro
@@ -232,13 +232,15 @@ const grouped: GroupedTool[] = categoryOrder
         // Restore persisted collapsed state
         if (collapsed.includes(id)) {
           cat.setAttribute("aria-expanded", "false");
-          list.classList.add("sidebar-list--collapsed");
+          list.style.display = "none";
+          cat.style.transform = "rotate(-90deg)";
         }
 
         function toggle() {
           const isExpanded = cat.getAttribute("aria-expanded") !== "false";
           cat.setAttribute("aria-expanded", isExpanded ? "false" : "true");
-          list!.classList.toggle("sidebar-list--collapsed", isExpanded);
+          list!.style.display = isExpanded ? "none" : "";
+          cat!.style.transform = isExpanded ? "rotate(-90deg)" : "";
 
           // Persist
           const nowCollapsed = Array.from(
@@ -418,12 +420,6 @@ const grouped: GroupedTool[] = categoryOrder
     color: var(--text-secondary);
     display: inline-block;
     transition: transform 0.15s ease;
-  }
-  .sidebar-category[aria-expanded="false"]::before {
-    transform: rotate(-90deg);
-  }
-  .sidebar-list--collapsed {
-    display: none;
   }
 
   .sidebar-list {

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | undefined | null)[]): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1,0 +1,164 @@
+---
+import LandingShell from "@/layouts/LandingShell.astro";
+import Button from "@/components/primitives/solid/Button";
+import Input from "@/components/primitives/solid/Input";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Select from "@/components/primitives/solid/Select";
+import Badge from "@/components/primitives/solid/Badge";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
+import PlaygroundApp from "@/components/primitives/solid/PlaygroundApp";
+---
+
+<LandingShell title="Component Playground — unwrapped.tools">
+  <main>
+    <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-8">Component Playground</h1>
+
+    <!-- Buttons -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Button
+      </h2>
+
+      <h3 class="text-xs font-medium text-[var(--text-muted)] mb-2">Primary</h3>
+      <div class="flex flex-wrap gap-3 mb-4">
+        <Button variant="primary" size="sm" client:load>Small</Button>
+        <Button variant="primary" size="md" client:load>Medium</Button>
+        <Button variant="primary" size="lg" client:load>Large</Button>
+        <Button variant="primary" disabled client:load>Disabled</Button>
+      </div>
+
+      <h3 class="text-xs font-medium text-[var(--text-muted)] mb-2">Secondary</h3>
+      <div class="flex flex-wrap gap-3 mb-4">
+        <Button variant="secondary" size="sm" client:load>Small</Button>
+        <Button variant="secondary" size="md" client:load>Medium</Button>
+        <Button variant="secondary" size="lg" client:load>Large</Button>
+        <Button variant="secondary" disabled client:load>Disabled</Button>
+      </div>
+
+      <h3 class="text-xs font-medium text-[var(--text-muted)] mb-2">Ghost</h3>
+      <div class="flex flex-wrap gap-3">
+        <Button variant="ghost" size="sm" client:load>Small</Button>
+        <Button variant="ghost" size="md" client:load>Medium</Button>
+        <Button variant="ghost" size="lg" client:load>Large</Button>
+        <Button variant="ghost" disabled client:load>Disabled</Button>
+      </div>
+    </section>
+
+    <!-- Input -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Input
+      </h2>
+      <div class="flex flex-col gap-4 max-w-md">
+        <Input label="Label" placeholder="Placeholder text..." client:load />
+        <Input label="With Value" value="Hello, world!" client:load />
+        <Input placeholder="No label" client:load />
+      </div>
+    </section>
+
+    <!-- Textarea -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Textarea
+      </h2>
+      <div class="flex flex-col gap-4 max-w-md">
+        <Textarea label="Description" placeholder="Write something..." client:load />
+        <Textarea label="With Content" value="Line 1\nLine 2\nLine 3" client:load />
+      </div>
+    </section>
+
+    <!-- Select -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Select
+      </h2>
+      <div class="max-w-md">
+        <Select
+          label="Pick an option"
+          options={[
+            { value: "option-1", label: "Option 1" },
+            { value: "option-2", label: "Option 2" },
+            { value: "option-3", label: "Option 3" },
+          ]}
+          client:load
+        />
+      </div>
+    </section>
+
+    <!-- Badge -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Badge
+      </h2>
+      <div class="flex flex-wrap gap-3">
+        <Badge tone="muted" client:load>Muted</Badge>
+        <Badge tone="success" client:load>Success</Badge>
+        <Badge tone="warning" client:load>Warning</Badge>
+        <Badge tone="error" client:load>Error</Badge>
+      </div>
+    </section>
+
+    <!-- Card -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Card
+      </h2>
+      <div class="max-w-md">
+        <Card client:load>
+          <p class="text-[var(--text-primary)] text-sm mb-2">This is a card component.</p>
+          <p class="text-[var(--text-secondary)] text-xs">
+            It has a rounded border and subtle background.
+          </p>
+        </Card>
+      </div>
+    </section>
+
+    <!-- Label -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Label
+      </h2>
+      <Label client:load>Standalone Label</Label>
+    </section>
+
+    <!-- Combined Example -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Combined Example
+      </h2>
+      <div class="max-w-lg">
+        <Card client:load>
+          <h3 class="text-sm font-semibold text-[var(--text-primary)] mb-4">Create Project</h3>
+          <div class="flex flex-col gap-4">
+            <Input label="Project Name" placeholder="my-awesome-project" client:load />
+            <Select
+              label="Framework"
+              options={[
+                { value: "astro", label: "Astro" },
+                { value: "solid", label: "SolidJS" },
+                { value: "react", label: "React" },
+              ]}
+              client:load
+            />
+            <Textarea label="Description" placeholder="Brief description..." client:load />
+            <div class="flex items-center justify-between">
+              <div class="flex gap-2">
+                <Badge tone="success" client:load>Ready</Badge>
+              </div>
+              <Button variant="primary" client:load>Create</Button>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </section>
+
+    <!-- Interactive playground (stateful) -->
+    <section class="mb-10">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-4">
+        Interactive Example
+      </h2>
+      <PlaygroundApp client:load />
+    </section>
+  </main>
+</LandingShell>


### PR DESCRIPTION
## Summary

Create a shadcn-inspired component primitive library for the upcoming tool page redesign. Components use only Tailwind utility classes (no inline CSS), merge custom classes via a `cn()` utility, and export typed SolidJS interfaces. A `/playground` route renders all primitives in every variant for visual audit and verification.

## Changes

- Add `src/lib/cn.ts` — lightweight class name utility for merging Tailwind classes
- Add `Button` component — primary/secondary/ghost variants, sm/md/lg sizes, disabled state
- Add `Input` component — text input with optional label
- Add `Textarea` component — textarea with same styling as Input
- Add `Select` component — select dropdown with `{value, label}` options
- Add `Badge` component — muted/success/warning/error pill
- Add `Card` component — rounded container with border
- Add `Label` component — uppercase label text
- Add `/playground` route — renders all primitives in all variants for visual audit (removed before v0.7.0)
- Fix EditorShell sidebar lint warnings — inline runtime-only CSS into JavaScript

## Testing

**Automated**
- [x] `bun run verify` passed (type-check ✓, lint ✓, format ✓, build ✓, 172 tests ✓)
- [x] All 27 static pages build successfully (26 existing + /playground)

**Manual**
- [ ] Visit `/playground` to visually audit every primitive variant
- [ ] Verify `onInput` callbacks fire correctly on Input, Textarea, Select
- [ ] Verify Button onClick and disabled states work