### PR TITLE
refactor: migrate 7 tools to primitive components

### DIFF
--- a/src/components/primitives/solid/Textarea.tsx
+++ b/src/components/primitives/solid/Textarea.tsx
@@ -8,6 +8,9 @@ export interface TextareaProps {
   placeholder?: string;
   rows?: number;
   class?: string;
+  error?: boolean;
+  autofocus?: boolean;
+  spellcheck?: boolean;
 }
 
 export default function Textarea(props: TextareaProps) {
@@ -19,7 +22,12 @@ export default function Textarea(props: TextareaProps) {
         onInput={(e) => props.onInput?.((e.target as HTMLTextAreaElement).value)}
         placeholder={props.placeholder}
         rows={props.rows ?? 4}
-        class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono resize-y focus:border-[var(--accent-primary)]"
+        autofocus={props.autofocus}
+        spellcheck={props.spellcheck ?? true}
+        class={cn(
+          "w-full rounded-lg border bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono resize-y transition-[border-color] duration-150 focus:border-[var(--accent-primary)]",
+          props.error ? "border-[var(--accent-error)]" : "border-[var(--border)]"
+        )}
       />
     </div>
   );

--- a/src/tools/json-formatter/JsonFormatter.tsx
+++ b/src/tools/json-formatter/JsonFormatter.tsx
@@ -1,6 +1,8 @@
 import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Label from "@/components/primitives/solid/Label";
 import { formatJson, type IndentSize, type JsonFormatResult } from "@/lib/jsonFormatter";
 
 export default function JsonFormatter() {
@@ -12,41 +14,16 @@ export default function JsonFormatter() {
     (): JsonFormatResult => formatJson(input(), indent(), minify(), sortKeys())
   );
 
-  const tabStyle = (active: boolean) => ({
-    padding: "0.25rem 0.625rem",
-    "border-radius": "0.25rem",
-    "font-size": "0.75rem",
-    "font-weight": "600",
-    cursor: "pointer",
-    border: "none",
-    background: active ? "var(--accent-primary)" : "transparent",
-    color: active ? "var(--bg-primary)" : "var(--text-secondary)",
-    transition: "background 0.15s, color 0.15s",
-  });
-
   return (
-    <div class="tool-container">
-      <div
-        style={{
-          display: "flex",
-          "align-items": "center",
-          "flex-wrap": "wrap",
-          gap: "0.75rem",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            "align-items": "center",
-            gap: "0.25rem",
-            padding: "0.25rem",
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "0.375rem",
-          }}
-        >
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
+      <div class="flex items-center flex-wrap gap-3">
+        <div class="flex items-center gap-1 p-1 rounded-md border border-[var(--border)] bg-[var(--bg-secondary)]">
           <button
-            style={tabStyle(indent() === 2 && !minify())}
+            classList={{
+              "px-2.5 py-1 text-xs font-semibold rounded cursor-pointer border-none transition-[background,color] duration-150": true,
+              "bg-[var(--accent-primary)] text-[var(--bg-primary)]": indent() === 2 && !minify(),
+              "bg-transparent text-[var(--text-secondary)]": !(indent() === 2 && !minify()),
+            }}
             onClick={() => {
               setIndent(2);
               setMinify(false);
@@ -55,7 +32,11 @@ export default function JsonFormatter() {
             2 spaces
           </button>
           <button
-            style={tabStyle(indent() === 4 && !minify())}
+            classList={{
+              "px-2.5 py-1 text-xs font-semibold rounded cursor-pointer border-none transition-[background,color] duration-150": true,
+              "bg-[var(--accent-primary)] text-[var(--bg-primary)]": indent() === 4 && !minify(),
+              "bg-transparent text-[var(--text-secondary)]": !(indent() === 4 && !minify()),
+            }}
             onClick={() => {
               setIndent(4);
               setMinify(false);
@@ -66,17 +47,12 @@ export default function JsonFormatter() {
         </div>
 
         <button
-          style={{
-            padding: "0.25rem 0.75rem",
-            "border-radius": "0.375rem",
-            border: `1px solid ${minify() ? "var(--accent-primary)" : "var(--border)"}`,
-            background: minify()
-              ? "color-mix(in srgb, var(--accent-primary) 15%, transparent)"
-              : "var(--bg-secondary)",
-            color: minify() ? "var(--accent-primary)" : "var(--text-secondary)",
-            "font-size": "0.75rem",
-            "font-weight": "600",
-            cursor: "pointer",
+          classList={{
+            "px-3 py-1 text-xs font-semibold rounded-md cursor-pointer border transition-[background,color] duration-150": true,
+            "bg-[color-mix(in_srgb,var(--accent-primary)_15%,transparent)] text-[var(--accent-primary)] border-[var(--accent-primary)]":
+              minify(),
+            "bg-[var(--bg-secondary)] text-[var(--text-secondary)] border-[var(--border)]":
+              !minify(),
           }}
           onClick={() => setMinify((value) => !value)}
         >
@@ -84,17 +60,12 @@ export default function JsonFormatter() {
         </button>
 
         <button
-          style={{
-            padding: "0.25rem 0.75rem",
-            "border-radius": "0.375rem",
-            border: `1px solid ${sortKeys() ? "var(--accent-primary)" : "var(--border)"}`,
-            background: sortKeys()
-              ? "color-mix(in srgb, var(--accent-primary) 15%, transparent)"
-              : "var(--bg-secondary)",
-            color: sortKeys() ? "var(--accent-primary)" : "var(--text-secondary)",
-            "font-size": "0.75rem",
-            "font-weight": "600",
-            cursor: "pointer",
+          classList={{
+            "px-3 py-1 text-xs font-semibold rounded-md cursor-pointer border transition-[background,color] duration-150": true,
+            "bg-[color-mix(in_srgb,var(--accent-primary)_15%,transparent)] text-[var(--accent-primary)] border-[var(--accent-primary)]":
+              sortKeys(),
+            "bg-[var(--bg-secondary)] text-[var(--text-secondary)] border-[var(--border)]":
+              !sortKeys(),
           }}
           onClick={() => setSortKeys((value) => !value)}
         >
@@ -103,16 +74,7 @@ export default function JsonFormatter() {
 
         <Show when={input().trim()}>
           <button
-            style={{
-              "margin-left": "auto",
-              padding: "0.25rem 0.75rem",
-              "border-radius": "0.375rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-secondary)",
-              color: "var(--text-muted)",
-              "font-size": "0.75rem",
-              cursor: "pointer",
-            }}
+            class="ml-auto px-3 py-1 text-xs font-semibold rounded-md cursor-pointer border border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-muted)]"
             onClick={() => setInput("")}
           >
             Clear
@@ -120,68 +82,32 @@ export default function JsonFormatter() {
         </Show>
       </div>
 
-      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">Input JSON</label>
-        <textarea
-          value={input()}
-          onInput={(e) => setInput(e.currentTarget.value)}
-          placeholder="Paste JSON here…"
-          rows={10}
-          autofocus
-          spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${result().error ? "var(--accent-error)" : "var(--border)"}`,
-            transition: "border-color 0.15s",
-          }}
-        />
-      </div>
+      <Textarea
+        label="Input JSON"
+        value={input()}
+        onInput={(value) => setInput(value)}
+        placeholder="Paste JSON here…"
+        rows={10}
+        autofocus
+        spellcheck={false}
+        error={!!result().error}
+      />
 
       <Show when={result().error}>
         {(msg) => (
           <div
             role="alert"
-            style={{
-              display: "flex",
-              "flex-direction": "column",
-              gap: "0.75rem",
-              padding: "0.75rem 1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--accent-error)",
-              background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
-              color: "var(--accent-error)",
-              "font-size": "0.875rem",
-            }}
+            class="flex flex-col gap-3 p-3 rounded-lg border border-[var(--accent-error)] bg-[color-mix(in_srgb,var(--accent-error)_12%,transparent)] text-[var(--accent-error)] text-sm"
           >
-            <div style={{ "font-family": "var(--font-mono)" }}>{msg()}</div>
+            <div class="font-mono">{msg()}</div>
             <Show when={result().errorLine && result().errorColumn}>
-              <div
-                style={{
-                  color: "var(--text-secondary)",
-                  "font-size": "0.8125rem",
-                  "font-family": "var(--font-mono)",
-                }}
-              >
+              <div class="text-[var(--text-secondary)] text-[0.8125rem] font-mono">
                 Line {result().errorLine}, column {result().errorColumn}
               </div>
             </Show>
             <Show when={result().errorContext}>
               {(context) => (
-                <pre
-                  style={{
-                    margin: "0",
-                    padding: "0.75rem",
-                    background: "color-mix(in srgb, var(--bg-secondary) 88%, transparent)",
-                    color: "var(--text-primary)",
-                    border: "1px solid var(--border)",
-                    "border-radius": "0.375rem",
-                    "font-size": "0.8125rem",
-                    "line-height": "1.5",
-                    "font-family": "var(--font-mono)",
-                    "white-space": "pre-wrap",
-                    "word-break": "break-word",
-                  }}
-                >
+                <pre class="m-0 p-3 bg-[color-mix(in_srgb,var(--bg-secondary)_88%,transparent)] text-[var(--text-primary)] border border-[var(--border)] rounded-md text-[0.8125rem] leading-normal font-mono whitespace-pre-wrap break-words">
                   {context()}
                 </pre>
               )}
@@ -192,43 +118,18 @@ export default function JsonFormatter() {
 
       <Show when={result().html}>
         {(html) => (
-          <div
-            style={{
-              background: "var(--bg-secondary)",
-              border: "1px solid var(--border)",
-              "border-radius": "0.5rem",
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                "align-items": "center",
-                "justify-content": "space-between",
-                padding: "0.625rem 1rem",
-                "border-bottom": "1px solid var(--border)",
-              }}
-            >
-              <span class="tool-label">
+          <div class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg overflow-hidden">
+            <div class="flex items-center justify-between px-4 py-2.5 border-b border-[var(--border)]">
+              <Label>
                 {minify()
                   ? `Minified${sortKeys() ? " · sorted" : ""}`
                   : `Formatted · ${indent()} spaces${sortKeys() ? " · sorted" : ""}`}
-              </span>
+              </Label>
               <CopyButton text={result().raw} />
             </div>
 
             <pre
-              style={{
-                margin: "0",
-                padding: "1rem",
-                "overflow-x": "auto",
-                "font-size": "0.8125rem",
-                "line-height": "1.6",
-                color: "var(--text-primary)",
-                "font-family": "var(--font-mono)",
-                "white-space": "pre-wrap",
-                "word-break": "break-all",
-              }}
+              class="m-0 p-4 overflow-x-auto text-[0.8125rem] leading-[1.6] text-[var(--text-primary)] font-mono whitespace-pre-wrap break-all"
               innerHTML={html()}
             />
           </div>

--- a/src/tools/json-to-csv/JsonToCsvTool.tsx
+++ b/src/tools/json-to-csv/JsonToCsvTool.tsx
@@ -2,6 +2,9 @@ import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
 import { convertJsonToCsv } from "@/lib/jsonToCsv";
 
 export default function JsonToCsvTool() {
@@ -17,44 +20,20 @@ export default function JsonToCsvTool() {
   });
 
   return (
-    <div
-      class="tool-container"
-      style={{
-        "--tool-max-width": "1100px",
-        display: "grid",
-        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
-      }}
-    >
-      <section style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">JSON array input</label>
-        <textarea
-          value={input()}
-          onInput={(event) => setInput(event.currentTarget.value)}
-          placeholder="Paste an array of JSON objects to convert…"
-          rows={14}
-          spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
-          }}
-        />
-      </section>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-5 p-6 mx-auto w-full max-w-[1100px]">
+      <Textarea
+        label="JSON array input"
+        value={input()}
+        onInput={(value) => setInput(value)}
+        placeholder="Paste an array of JSON objects to convert…"
+        rows={14}
+        spellcheck={false}
+        error={!!error()}
+      />
 
-      <section
-        style={{
-          display: "flex",
-          "flex-direction": "column",
-          gap: "0.75rem",
-          padding: "1rem",
-          background: "var(--bg-secondary)",
-          border: "1px solid var(--border)",
-          "border-radius": "0.75rem",
-        }}
-      >
-        <div
-          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
-        >
-          <span class="tool-label">CSV output</span>
+      <Card class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <Label>CSV output</Label>
           <CopyButton text={output()} label="Copy CSV" />
         </div>
 
@@ -62,26 +41,11 @@ export default function JsonToCsvTool() {
           when={!error()}
           fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
         >
-          <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-primary)",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "font-size": "0.875rem",
-              "line-height": "1.7",
-              "white-space": "pre-wrap",
-              "word-break": "break-word",
-              "min-height": "20rem",
-            }}
-          >
+          <pre class="m-0 p-4 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)] font-mono text-sm leading-relaxed whitespace-pre-wrap break-words min-h-[20rem]">
             {output() || "—"}
           </pre>
         </Show>
-      </section>
+      </Card>
     </div>
   );
 }

--- a/src/tools/json-to-yaml/JsonToYamlTool.tsx
+++ b/src/tools/json-to-yaml/JsonToYamlTool.tsx
@@ -2,6 +2,9 @@ import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
 import { convertJsonToYaml } from "@/lib/jsonToYaml";
 
 export default function JsonToYamlTool() {
@@ -17,44 +20,20 @@ export default function JsonToYamlTool() {
   });
 
   return (
-    <div
-      class="tool-container"
-      style={{
-        "--tool-max-width": "1100px",
-        display: "grid",
-        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
-      }}
-    >
-      <section style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">JSON input</label>
-        <textarea
-          value={input()}
-          onInput={(event) => setInput(event.currentTarget.value)}
-          placeholder="Paste JSON to convert…"
-          rows={14}
-          spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
-          }}
-        />
-      </section>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-5 p-6 mx-auto w-full max-w-[1100px]">
+      <Textarea
+        label="JSON input"
+        value={input()}
+        onInput={(value) => setInput(value)}
+        placeholder="Paste JSON to convert…"
+        rows={14}
+        spellcheck={false}
+        error={!!error()}
+      />
 
-      <section
-        style={{
-          display: "flex",
-          "flex-direction": "column",
-          gap: "0.75rem",
-          padding: "1rem",
-          background: "var(--bg-secondary)",
-          border: "1px solid var(--border)",
-          "border-radius": "0.75rem",
-        }}
-      >
-        <div
-          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
-        >
-          <span class="tool-label">YAML output</span>
+      <Card class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <Label>YAML output</Label>
           <CopyButton text={output()} label="Copy YAML" />
         </div>
 
@@ -62,26 +41,11 @@ export default function JsonToYamlTool() {
           when={!error()}
           fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
         >
-          <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-primary)",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "font-size": "0.875rem",
-              "line-height": "1.7",
-              "white-space": "pre-wrap",
-              "word-break": "break-word",
-              "min-height": "20rem",
-            }}
-          >
+          <pre class="m-0 p-4 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)] font-mono text-sm leading-relaxed whitespace-pre-wrap break-words min-h-[20rem]">
             {output() || "—"}
           </pre>
         </Show>
-      </section>
+      </Card>
     </div>
   );
 }

--- a/src/tools/url-inspector/UrlInspectorTool.tsx
+++ b/src/tools/url-inspector/UrlInspectorTool.tsx
@@ -2,6 +2,9 @@ import { createMemo, createSignal, For, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
 import { inspectUrl } from "@/lib/urlInspector";
 
 const SECTION_LABELS = [
@@ -31,32 +34,21 @@ export default function UrlInspectorTool() {
   });
 
   return (
-    <div class="tool-container" style={{ "--tool-max-width": "1100px" }}>
-      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">URL or raw query string</label>
-        <textarea
-          value={input()}
-          onInput={(event) => setInput(event.currentTarget.value)}
-          rows={5}
-          spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
-          }}
-        />
-      </div>
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[1100px]">
+      <Textarea
+        label="URL or raw query string"
+        value={input()}
+        onInput={(value) => setInput(value)}
+        rows={5}
+        spellcheck={false}
+        error={!!error()}
+      />
 
       <Show
         when={!error()}
         fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
       >
-        <div
-          style={{
-            display: "grid",
-            gap: "0.75rem",
-            "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
-          }}
-        >
+        <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
           <For each={SECTION_LABELS}>
             {([key, label]) => {
               const value = () => {
@@ -66,80 +58,42 @@ export default function UrlInspectorTool() {
               };
 
               return (
-                <section
-                  style={{
-                    display: "flex",
-                    "flex-direction": "column",
-                    gap: "0.5rem",
-                    padding: "0.875rem",
-                    background: "var(--bg-secondary)",
-                    border: "1px solid var(--border)",
-                    "border-radius": "0.5rem",
-                  }}
-                >
-                  <div
-                    style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}
-                  >
-                    <span class="tool-label">{label}</span>
+                <Card class="flex flex-col gap-2">
+                  <div class="flex justify-between gap-3">
+                    <Label>{label}</Label>
                     <CopyButton text={value()} label={`Copy ${label}`} />
                   </div>
-                  <code
-                    style={{
-                      color: "var(--text-primary)",
-                      "font-size": "0.875rem",
-                      "line-height": "1.6",
-                      "word-break": "break-all",
-                    }}
-                  >
+                  <code class="text-[var(--text-primary)] text-sm leading-relaxed break-all">
                     {value() || "—"}
                   </code>
-                </section>
+                </Card>
               );
             }}
           </For>
         </div>
 
-        <section
-          style={{
-            display: "flex",
-            "flex-direction": "column",
-            gap: "0.75rem",
-            padding: "1rem",
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "0.75rem",
-          }}
-        >
-          <div style={{ display: "flex", "justify-content": "space-between", gap: "0.75rem" }}>
-            <span class="tool-label">Decoded query params</span>
+        <Card class="flex flex-col gap-3">
+          <div class="flex justify-between gap-3">
+            <Label>Decoded query params</Label>
             <Show when={inspection()?.normalized}>
-              <ToolStatusMessage tone="muted" style={{ padding: "0.375rem 0.625rem" }}>
+              <span class="text-xs px-1.5 py-1 rounded bg-[var(--bg-tertiary)] text-[var(--text-secondary)]">
                 {inspection()?.kind === "query" ? "raw query" : "full url"}
-              </ToolStatusMessage>
+              </span>
             </Show>
           </div>
 
-          <div style={{ overflow: "auto" }}>
-            <table style={{ width: "100%", "border-collapse": "collapse" }}>
+          <div class="overflow-auto">
+            <table class="w-full border-collapse">
               <thead>
                 <tr>
-                  <th
-                    class="tool-label"
-                    style={{ padding: "0.5rem 0.75rem", "text-align": "left" }}
-                  >
-                    #
+                  <th class="px-3 py-2 text-left">
+                    <Label>#</Label>
                   </th>
-                  <th
-                    class="tool-label"
-                    style={{ padding: "0.5rem 0.75rem", "text-align": "left" }}
-                  >
-                    Key
+                  <th class="px-3 py-2 text-left">
+                    <Label>Key</Label>
                   </th>
-                  <th
-                    class="tool-label"
-                    style={{ padding: "0.5rem 0.75rem", "text-align": "left" }}
-                  >
-                    Value
+                  <th class="px-3 py-2 text-left">
+                    <Label>Value</Label>
                   </th>
                 </tr>
               </thead>
@@ -147,13 +101,11 @@ export default function UrlInspectorTool() {
                 <For each={inspection()?.queryParams ?? []}>
                   {(param, index) => (
                     <tr>
-                      <td style={{ padding: "0.5rem 0.75rem", color: "var(--text-muted)" }}>
-                        {index() + 1}
-                      </td>
-                      <td style={{ padding: "0.5rem 0.75rem", color: "var(--text-primary)" }}>
+                      <td class="px-3 py-2 text-[var(--text-muted)]">{index() + 1}</td>
+                      <td class="px-3 py-2 text-[var(--text-primary)]">
                         <code>{param.key || "—"}</code>
                       </td>
-                      <td style={{ padding: "0.5rem 0.75rem", color: "var(--text-primary)" }}>
+                      <td class="px-3 py-2 text-[var(--text-primary)]">
                         <code>{param.value || "—"}</code>
                       </td>
                     </tr>
@@ -166,7 +118,7 @@ export default function UrlInspectorTool() {
           <Show when={(inspection()?.queryParams.length ?? 0) === 0}>
             <ToolStatusMessage tone="muted">No query params found.</ToolStatusMessage>
           </Show>
-        </section>
+        </Card>
       </Show>
     </div>
   );

--- a/src/tools/xml-formatter/XmlFormatterTool.tsx
+++ b/src/tools/xml-formatter/XmlFormatterTool.tsx
@@ -2,6 +2,9 @@ import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
 import { formatXml } from "@/lib/xmlFormatter";
 
 export default function XmlFormatterTool() {
@@ -18,64 +21,34 @@ export default function XmlFormatterTool() {
   });
 
   return (
-    <div
-      class="tool-container"
-      style={{
-        "--tool-max-width": "1100px",
-        display: "grid",
-        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
-      }}
-    >
-      <section style={{ display: "flex", "flex-direction": "column", gap: "0.75rem" }}>
-        <div
-          style={{ display: "flex", "align-items": "center", gap: "0.75rem", "flex-wrap": "wrap" }}
-        >
-          <label class="tool-label">Indent</label>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-5 p-6 mx-auto w-full max-w-[1100px]">
+      <div class="flex flex-col gap-3">
+        <div class="flex items-center gap-3 flex-wrap">
+          <Label>Indent</Label>
           <input
             type="number"
             min={2}
             max={8}
             value={indent()}
             onInput={(event) => setIndent(Number(event.currentTarget.value) || 2)}
-            style={{
-              width: "5rem",
-              padding: "0.5rem 0.75rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-secondary)",
-              color: "var(--text-primary)",
-            }}
+            class="w-20 rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none"
           />
         </div>
 
-        <textarea
+        <Textarea
+          label="XML input"
           value={input()}
-          onInput={(event) => setInput(event.currentTarget.value)}
+          onInput={(value) => setInput(value)}
           placeholder="Paste XML to format…"
           rows={14}
           spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
-          }}
+          error={!!error()}
         />
-      </section>
+      </div>
 
-      <section
-        style={{
-          display: "flex",
-          "flex-direction": "column",
-          gap: "0.75rem",
-          padding: "1rem",
-          background: "var(--bg-secondary)",
-          border: "1px solid var(--border)",
-          "border-radius": "0.75rem",
-        }}
-      >
-        <div
-          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
-        >
-          <span class="tool-label">Formatted XML</span>
+      <Card class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <Label>Formatted XML</Label>
           <CopyButton text={output()} label="Copy XML" />
         </div>
 
@@ -83,26 +56,11 @@ export default function XmlFormatterTool() {
           when={!error()}
           fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
         >
-          <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-primary)",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "font-size": "0.875rem",
-              "line-height": "1.7",
-              "white-space": "pre-wrap",
-              "word-break": "break-word",
-              "min-height": "20rem",
-            }}
-          >
+          <pre class="m-0 p-4 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)] font-mono text-sm leading-relaxed whitespace-pre-wrap break-words min-h-[20rem]">
             {output() || "—"}
           </pre>
         </Show>
-      </section>
+      </Card>
     </div>
   );
 }

--- a/src/tools/yaml-formatter/YamlFormatterTool.tsx
+++ b/src/tools/yaml-formatter/YamlFormatterTool.tsx
@@ -3,6 +3,9 @@ import { createMemo, createSignal, Show } from "solid-js";
 import CopyButton from "@/components/CopyButton";
 import ToolActionButton from "@/components/ToolActionButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
 import { formatYaml } from "@/lib/yamlFormatter";
 
 export default function YamlFormatterTool() {
@@ -21,67 +24,37 @@ export default function YamlFormatterTool() {
   });
 
   return (
-    <div
-      class="tool-container"
-      style={{
-        "--tool-max-width": "1100px",
-        display: "grid",
-        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
-      }}
-    >
-      <section style={{ display: "flex", "flex-direction": "column", gap: "0.75rem" }}>
-        <div
-          style={{ display: "flex", "align-items": "center", gap: "0.75rem", "flex-wrap": "wrap" }}
-        >
-          <label class="tool-label">Indent</label>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-5 p-6 mx-auto w-full max-w-[1100px]">
+      <div class="flex flex-col gap-3">
+        <div class="flex items-center gap-3 flex-wrap">
+          <Label>Indent</Label>
           <input
             type="number"
             min={2}
             max={8}
             value={indent()}
             onInput={(event) => setIndent(Number(event.currentTarget.value) || 2)}
-            style={{
-              width: "5rem",
-              padding: "0.5rem 0.75rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-secondary)",
-              color: "var(--text-primary)",
-            }}
+            class="w-20 rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none"
           />
           <ToolActionButton active={sortKeys()} onClick={() => setSortKeys((current) => !current)}>
             Sort keys
           </ToolActionButton>
         </div>
 
-        <textarea
+        <Textarea
+          label="YAML input"
           value={input()}
-          onInput={(event) => setInput(event.currentTarget.value)}
+          onInput={(value) => setInput(value)}
           placeholder="Paste YAML to format…"
           rows={14}
           spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
-          }}
+          error={!!error()}
         />
-      </section>
+      </div>
 
-      <section
-        style={{
-          display: "flex",
-          "flex-direction": "column",
-          gap: "0.75rem",
-          padding: "1rem",
-          background: "var(--bg-secondary)",
-          border: "1px solid var(--border)",
-          "border-radius": "0.75rem",
-        }}
-      >
-        <div
-          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
-        >
-          <span class="tool-label">Formatted YAML</span>
+      <Card class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <Label>Formatted YAML</Label>
           <CopyButton text={output()} label="Copy YAML" />
         </div>
 
@@ -89,26 +62,11 @@ export default function YamlFormatterTool() {
           when={!error()}
           fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
         >
-          <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-primary)",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "font-size": "0.875rem",
-              "line-height": "1.7",
-              "white-space": "pre-wrap",
-              "word-break": "break-word",
-              "min-height": "20rem",
-            }}
-          >
+          <pre class="m-0 p-4 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)] font-mono text-sm leading-relaxed whitespace-pre-wrap break-words min-h-[20rem]">
             {output() || "—"}
           </pre>
         </Show>
-      </section>
+      </Card>
     </div>
   );
 }

--- a/src/tools/yaml-to-json/YamlToJsonTool.tsx
+++ b/src/tools/yaml-to-json/YamlToJsonTool.tsx
@@ -2,6 +2,9 @@ import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Textarea from "@/components/primitives/solid/Textarea";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
 import { convertYamlToJson } from "@/lib/yamlToJson";
 
 export default function YamlToJsonTool() {
@@ -17,44 +20,20 @@ export default function YamlToJsonTool() {
   });
 
   return (
-    <div
-      class="tool-container"
-      style={{
-        "--tool-max-width": "1100px",
-        display: "grid",
-        "grid-template-columns": "repeat(auto-fit, minmax(320px, 1fr))",
-      }}
-    >
-      <section style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">YAML input</label>
-        <textarea
-          value={input()}
-          onInput={(event) => setInput(event.currentTarget.value)}
-          placeholder="Paste YAML to convert…"
-          rows={14}
-          spellcheck={false}
-          class="tool-textarea"
-          style={{
-            border: `1px solid ${error() ? "var(--accent-error)" : "var(--border)"}`,
-          }}
-        />
-      </section>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-5 p-6 mx-auto w-full max-w-[1100px]">
+      <Textarea
+        label="YAML input"
+        value={input()}
+        onInput={(value) => setInput(value)}
+        placeholder="Paste YAML to convert…"
+        rows={14}
+        spellcheck={false}
+        error={!!error()}
+      />
 
-      <section
-        style={{
-          display: "flex",
-          "flex-direction": "column",
-          gap: "0.75rem",
-          padding: "1rem",
-          background: "var(--bg-secondary)",
-          border: "1px solid var(--border)",
-          "border-radius": "0.75rem",
-        }}
-      >
-        <div
-          style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}
-        >
-          <span class="tool-label">JSON output</span>
+      <Card class="flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <Label>JSON output</Label>
           <CopyButton text={output()} label="Copy JSON" />
         </div>
 
@@ -62,26 +41,11 @@ export default function YamlToJsonTool() {
           when={!error()}
           fallback={<ToolStatusMessage tone="error">{error()}</ToolStatusMessage>}
         >
-          <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "border-radius": "0.5rem",
-              border: "1px solid var(--border)",
-              background: "var(--bg-primary)",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "font-size": "0.875rem",
-              "line-height": "1.7",
-              "white-space": "pre-wrap",
-              "word-break": "break-word",
-              "min-height": "20rem",
-            }}
-          >
+          <pre class="m-0 p-4 rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] text-[var(--text-primary)] font-mono text-sm leading-relaxed whitespace-pre-wrap break-words min-h-[20rem]">
             {output() || "—"}
           </pre>
         </Show>
-      </section>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Migrate the remaining 7 formatter/converter tools from inline CSS to primitives + Tailwind. Also add an optional `error` prop to the Textarea component for conditional error border styling. Net -331 lines.

## Changes

- Add `error` prop to Textarea primitive — shows red border when true, used across all migrated tools
- `JsonFormatter`: removed `tabStyle()` helper; toolbar buttons now use Tailwind + classList; error display section uses Tailwind; Textarea uses `error` prop
- `JsonToYamlTool`, `YamlToJsonTool`, `JsonToCsvTool`: two-column grid pattern with Textarea + Card output
- `YamlFormatterTool`, `XmlFormatterTool`: same pattern with Indent number input
- `UrlInspectorTool`: URL info grid uses Card + Label; query params table uses Tailwind; kind badge uses Tailwind span
- Net: 181 insertions, 512 deletions

## Testing

**Automated**
- [x] `bun run verify` passed (type-check ✓, lint ✓, format ✓, build ✓, 172 tests ✓)

**Manual**
- [x] Visit `/tools/json-formatter` — verify tab buttons, minify/sort toggles, error display with line/column info
- [x] Visit `/tools/url-inspector` — verify URL info cards, query params table
- [x] Visit any converter tool — verify two-column layout, error borders on invalid input