### PR TITLE
refactor: migrate 5 complex tools to primitive components

### DIFF
--- a/src/components/primitives/solid/Textarea.tsx
+++ b/src/components/primitives/solid/Textarea.tsx
@@ -11,6 +11,7 @@ export interface TextareaProps {
   error?: boolean;
   autofocus?: boolean;
   spellcheck?: boolean;
+  readonly?: boolean;
 }
 
 export default function Textarea(props: TextareaProps) {
@@ -24,6 +25,7 @@ export default function Textarea(props: TextareaProps) {
         rows={props.rows ?? 4}
         autofocus={props.autofocus}
         spellcheck={props.spellcheck ?? true}
+        readonly={props.readonly}
         class={cn(
           "w-full rounded-lg border bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono resize-y transition-[border-color] duration-150 focus:border-[var(--accent-primary)]",
           props.error ? "border-[var(--accent-error)]" : "border-[var(--border)]"

--- a/src/tools/base64/Base64Tool.tsx
+++ b/src/tools/base64/Base64Tool.tsx
@@ -3,6 +3,9 @@ import { createMemo, createSignal, Show } from "solid-js";
 import CopyButton from "@/components/CopyButton";
 import ToolActionButton from "@/components/ToolActionButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
+import Textarea from "@/components/primitives/solid/Textarea";
 import {
   type Base64Mode,
   type Base64Variant,
@@ -192,22 +195,12 @@ export default function Base64Tool() {
   };
 
   return (
-    <div class="tool-container" style={{ "--tool-max-width": "860px" }}>
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[860px]">
       {/* ------------------------------------------------------------------ */}
       {/* Mode toggle + swap                                                  */}
       {/* ------------------------------------------------------------------ */}
-      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "0.5rem", "align-items": "center" }}>
-        <div
-          style={{
-            display: "flex",
-            "align-items": "center",
-            gap: "0.25rem",
-            padding: "0.25rem",
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "0.5rem",
-          }}
-        >
+      <div class="flex flex-wrap gap-2 items-center">
+        <div class="flex items-center gap-1 p-1 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg">
           <ToolActionButton
             active={mode() === "encode"}
             variant={mode() === "encode" ? "primary" : "ghost"}
@@ -224,7 +217,7 @@ export default function Base64Tool() {
           </ToolActionButton>
         </div>
 
-        <div style={{ display: "flex", gap: "0.25rem", "align-items": "center" }}>
+        <div class="flex gap-1 items-center">
           <ToolActionButton
             active={variant() === "standard"}
             variant={variant() === "standard" ? "primary" : "ghost"}
@@ -241,7 +234,7 @@ export default function Base64Tool() {
           </ToolActionButton>
         </div>
 
-        <div style={{ display: "flex", gap: "0.25rem", "align-items": "center" }}>
+        <div class="flex gap-1 items-center">
           <ToolActionButton
             active={workflow() === "text"}
             variant={workflow() === "text" ? "primary" : "ghost"}
@@ -258,9 +251,7 @@ export default function Base64Tool() {
           </ToolActionButton>
         </div>
 
-        <div
-          style={{ display: "flex", gap: "0.5rem", "align-items": "center", "margin-left": "auto" }}
-        >
+        <div class="flex gap-2 items-center ml-auto">
           <ToolActionButton onClick={swap} title="Swap input/output">
             ⇅ Swap
           </ToolActionButton>
@@ -273,8 +264,8 @@ export default function Base64Tool() {
       {/* ------------------------------------------------------------------ */}
       {/* Input                                                               */}
       {/* ------------------------------------------------------------------ */}
-      <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
-        <label class="tool-label">
+      <div class="flex flex-col gap-2">
+        <Label>
           {mode() === "encode"
             ? workflow() === "text"
               ? "Plain text"
@@ -282,22 +273,18 @@ export default function Base64Tool() {
             : variant() === "url"
               ? "Base64url"
               : "Base64"}
-        </label>
+        </Label>
 
         {/* Drop zone wrapper */}
-        <div
-          onDragOver={(e) => e.preventDefault()}
-          onDrop={onDrop}
-          style={{ position: "relative" }}
-        >
-          <textarea
+        <div onDragOver={(e) => e.preventDefault()} onDrop={onDrop}>
+          <Textarea
             value={mode() === "encode" && workflow() === "file" ? fileSummary() : input()}
             onInput={(e) => {
               setFileError(null);
               setFileNotice(null);
               setLoadedFile(null);
               setLoadedFileBytes(null);
-              setInput(e.currentTarget.value);
+              setInput(e);
             }}
             placeholder={
               mode() === "encode"
@@ -310,24 +297,17 @@ export default function Base64Tool() {
             }
             rows={8}
             spellcheck={false}
-            readOnly={mode() === "encode" && workflow() === "file"}
-            class="tool-textarea"
+            readonly={mode() === "encode" && workflow() === "file"}
           />
         </div>
 
         {/* File open button */}
-        <div style={{ display: "flex", "align-items": "center", gap: "0.5rem" }}>
-          <label
-            style={{
-              "font-size": "0.8125rem",
-              color: "var(--accent-primary)",
-              cursor: "pointer",
-            }}
-          >
+        <div class="flex items-center gap-2">
+          <label class="text-sm text-[var(--accent-primary)] cursor-pointer">
             Open file
             <input
               type="file"
-              style={{ display: "none" }}
+              class="hidden"
               onChange={(e) => {
                 const file = e.currentTarget.files?.[0];
                 if (file) handleFile(file);
@@ -335,7 +315,7 @@ export default function Base64Tool() {
               }}
             />
           </label>
-          <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>
+          <span class="text-sm text-[var(--text-muted)]">
             Local-only input handling with explicit text and file workflows
           </span>
         </div>
@@ -364,25 +344,10 @@ export default function Base64Tool() {
       {/* ------------------------------------------------------------------ */}
       <Show when={outputValue()}>
         {(value) => (
-          <div
-            style={{
-              background: "var(--bg-secondary)",
-              border: "1px solid var(--border)",
-              "border-radius": "0.5rem",
-              overflow: "hidden",
-            }}
-          >
+          <Card class="overflow-hidden p-0">
             {/* Output header */}
-            <div
-              style={{
-                display: "flex",
-                "align-items": "center",
-                "justify-content": "space-between",
-                padding: "0.625rem 1rem",
-                "border-bottom": "1px solid var(--border)",
-              }}
-            >
-              <span class="tool-label">
+            <div class="flex items-center justify-between px-4 py-2.5 border-b border-[var(--border)]">
+              <Label>
                 {mode() === "encode"
                   ? variant() === "url"
                     ? "Base64url"
@@ -390,29 +355,17 @@ export default function Base64Tool() {
                   : workflow() === "file"
                     ? "Decoded bytes · binary output"
                     : "Decoded text"}
-              </span>
+              </Label>
               <Show when={binaryOutput()} fallback={<CopyButton text={value()} />}>
                 <ToolActionButton onClick={downloadDecodedBytes}>Download file</ToolActionButton>
               </Show>
             </div>
 
             {/* Output body */}
-            <pre
-              style={{
-                margin: "0",
-                padding: "1rem",
-                "overflow-x": "auto",
-                "font-size": "0.8125rem",
-                "line-height": "1.6",
-                color: "var(--text-primary)",
-                "font-family": "var(--font-mono)",
-                "white-space": "pre-wrap",
-                "word-break": "break-all",
-              }}
-            >
+            <pre class="m-0 p-4 overflow-x-auto text-xs leading-relaxed text-[var(--text-primary)] font-mono whitespace-pre-wrap break-all">
               <code>{value()}</code>
             </pre>
-          </div>
+          </Card>
         )}
       </Show>
 

--- a/src/tools/hash-generator/HashGenerator.tsx
+++ b/src/tools/hash-generator/HashGenerator.tsx
@@ -3,6 +3,9 @@ import { createMemo, createSignal, For, onCleanup, Show } from "solid-js";
 import CopyButton from "@/components/CopyButton";
 import ToolActionButton from "@/components/ToolActionButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
+import Textarea from "@/components/primitives/solid/Textarea";
 import {
   DEFAULT_IMPORT_MAX_BYTES,
   type FileImportError,
@@ -145,16 +148,9 @@ export default function HashGenerator() {
   });
 
   return (
-    <div class="tool-container" style={{ "--tool-max-width": "860px" }}>
-      <div
-        style={{
-          display: "flex",
-          "flex-wrap": "wrap",
-          "align-items": "center",
-          gap: "0.75rem",
-        }}
-      >
-        <div style={{ display: "flex", gap: "0.25rem", "align-items": "center" }}>
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[860px]">
+      <div class="flex flex-wrap items-center gap-3">
+        <div class="flex gap-1 items-center">
           <ToolActionButton
             active={workflow() === "text"}
             variant={workflow() === "text" ? "primary" : "ghost"}
@@ -188,21 +184,17 @@ export default function HashGenerator() {
         >
           Clear
         </ToolActionButton>
-        <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>
+        <span class="text-xs text-[var(--text-muted)]">
           Local-only hashing via the browser&apos;s Web Crypto API
         </span>
       </div>
 
-      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">{workflow() === "text" ? "Input text" : "Input file"}</label>
-        <div
-          onDragOver={(event) => event.preventDefault()}
-          onDrop={onDrop}
-          style={{ position: "relative" }}
-        >
-          <textarea
+      <div class="flex flex-col gap-1.5">
+        <Label>{workflow() === "text" ? "Input text" : "Input file"}</Label>
+        <div onDragOver={(event) => event.preventDefault()} onDrop={onDrop}>
+          <Textarea
             value={workflow() === "file" ? fileSummary() : input()}
-            onInput={(event) => handleInput(event.currentTarget.value)}
+            onInput={(event) => handleInput(event)}
             placeholder={
               workflow() === "text"
                 ? "Type or paste text to hash…"
@@ -210,23 +202,16 @@ export default function HashGenerator() {
             }
             rows={5}
             spellcheck={false}
-            readOnly={workflow() === "file"}
-            class="tool-textarea"
+            readonly={workflow() === "file"}
           />
         </div>
 
-        <div style={{ display: "flex", "align-items": "center", gap: "0.5rem" }}>
-          <label
-            style={{
-              "font-size": "0.8125rem",
-              color: "var(--accent-primary)",
-              cursor: "pointer",
-            }}
-          >
+        <div class="flex items-center gap-2">
+          <label class="text-sm text-[var(--accent-primary)] cursor-pointer">
             Open file
             <input
               type="file"
-              style={{ display: "none" }}
+              class="hidden"
               onChange={(event) => {
                 const file = event.currentTarget.files?.[0];
                 if (file) {
@@ -236,7 +221,7 @@ export default function HashGenerator() {
               }}
             />
           </label>
-          <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>
+          <span class="text-sm text-[var(--text-muted)]">
             Shared local file import flow with explicit read and size failures
           </span>
         </div>
@@ -263,61 +248,21 @@ export default function HashGenerator() {
       </Show>
 
       <Show when={results().length > 0}>
-        <div
-          style={{
-            display: "flex",
-            "flex-direction": "column",
-            gap: "0.75rem",
-          }}
-        >
+        <div class="flex flex-col gap-3">
           <For each={results()}>
             {(result) => (
-              <div
-                style={{
-                  background: "var(--bg-secondary)",
-                  border: "1px solid var(--border)",
-                  "border-radius": "0.5rem",
-                  overflow: "hidden",
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    "align-items": "center",
-                    "justify-content": "space-between",
-                    padding: "0.5rem 1rem",
-                    "border-bottom": "1px solid var(--border)",
-                  }}
-                >
-                  <span
-                    style={{
-                      "font-size": "0.75rem",
-                      "font-weight": "700",
-                      "letter-spacing": "0.05em",
-                      "text-transform": "uppercase",
-                      color: "var(--accent-primary)",
-                    }}
-                  >
+              <Card class="overflow-hidden p-0">
+                <div class="flex items-center justify-between px-4 py-2 border-b border-[var(--border)]">
+                  <span class="text-xs font-bold tracking-wider uppercase text-[var(--accent-primary)]">
                     {result.algorithm}
                   </span>
                   <CopyButton text={result.hex} />
                 </div>
 
-                <pre
-                  style={{
-                    margin: "0",
-                    padding: "0.75rem 1rem",
-                    "font-size": "0.8125rem",
-                    "line-height": "1.6",
-                    color: "var(--text-primary)",
-                    "font-family": "var(--font-mono)",
-                    "white-space": "pre-wrap",
-                    "word-break": "break-all",
-                  }}
-                >
+                <pre class="m-0 p-3 px-4 text-xs leading-relaxed text-[var(--text-primary)] font-mono whitespace-pre-wrap break-all">
                   {result.hex}
                 </pre>
-              </div>
+              </Card>
             )}
           </For>
         </div>

--- a/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -1,6 +1,9 @@
 import { createMemo, createSignal, Show } from "solid-js";
 
 import CopyButton from "@/components/CopyButton";
+import Card from "@/components/primitives/solid/Card";
+import Label from "@/components/primitives/solid/Label";
+import Textarea from "@/components/primitives/solid/Textarea";
 import { getJwtClaimsSummary, getJwtExpiryStatus, parseJwt, prettyJson } from "@/lib/jwt";
 
 // ---------------------------------------------------------------------------
@@ -14,45 +17,18 @@ interface PanelProps {
 
 function Panel(props: PanelProps) {
   return (
-    <div
-      style={{
-        background: "var(--bg-secondary)",
-        border: "1px solid var(--border)",
-        "border-radius": "0.5rem",
-        overflow: "hidden",
-      }}
-    >
+    <Card class="overflow-hidden p-0">
       {/* Panel header */}
-      <div
-        style={{
-          display: "flex",
-          "align-items": "center",
-          "justify-content": "space-between",
-          padding: "0.625rem 1rem",
-          "border-bottom": "1px solid var(--border)",
-        }}
-      >
-        <span class="tool-label">{props.title}</span>
+      <div class="flex items-center justify-between px-4 py-2.5 border-b border-[var(--border)]">
+        <Label>{props.title}</Label>
         <CopyButton text={props.content} />
       </div>
 
       {/* Panel body */}
-      <pre
-        style={{
-          margin: "0",
-          padding: "1rem",
-          "overflow-x": "auto",
-          "font-family": "var(--font-mono)",
-          "font-size": "0.8125rem",
-          "line-height": "1.6",
-          color: "var(--text-primary)",
-          "white-space": "pre-wrap",
-          "word-break": "break-all",
-        }}
-      >
+      <pre class="m-0 p-4 overflow-x-auto font-mono text-xs leading-relaxed text-[var(--text-primary)] whitespace-pre-wrap break-all">
         <code>{props.content}</code>
       </pre>
-    </div>
+    </Card>
   );
 }
 
@@ -90,34 +66,21 @@ export default function JwtDecoder() {
   });
 
   return (
-    <div class="tool-container" style={{ "--tool-max-width": "860px" }}>
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[860px]">
       {/* ------------------------------------------------------------------ */}
       {/* Input area                                                          */}
       {/* ------------------------------------------------------------------ */}
-      <div
-        style={{
-          display: "flex",
-          "flex-direction": "column",
-          gap: "0.5rem",
-        }}
-      >
-        <textarea
+      <div class="flex flex-col gap-2">
+        <Textarea
           value={input()}
-          onInput={(e) => setInput(e.currentTarget.value)}
+          onInput={setInput}
           placeholder="Paste a JWT token here..."
           rows={5}
           spellcheck={false}
-          class="tool-textarea"
         />
         {/* Hint — only when input is empty */}
         <Show when={!input().trim()}>
-          <p
-            style={{
-              "font-size": "0.8125rem",
-              color: "var(--text-muted)",
-              margin: "0",
-            }}
-          >
+          <p class="text-xs text-[var(--text-muted)] m-0">
             Supports RS256, HS256, and all standard JWT algorithms
           </p>
         </Show>
@@ -129,14 +92,7 @@ export default function JwtDecoder() {
       <Show when={error()}>
         <div
           role="alert"
-          style={{
-            padding: "0.75rem 1rem",
-            "border-radius": "0.5rem",
-            border: "1px solid var(--accent-error)",
-            background: "color-mix(in srgb, var(--accent-error) 12%, transparent)",
-            color: "var(--accent-error)",
-            "font-size": "0.875rem",
-          }}
+          class="px-4 py-3 rounded-lg border border-[var(--accent-error)] bg-[color-mix(in_srgb,var(--accent-error)_12%,transparent)] text-[var(--accent-error)] text-sm"
         >
           {error()}
         </div>
@@ -152,114 +108,43 @@ export default function JwtDecoder() {
             <Show when={expiryStatus()}>
               {(status) => (
                 <div
-                  style={{
-                    display: "inline-flex",
-                    "align-self": "flex-start",
-                    "align-items": "center",
-                    gap: "0.375rem",
-                    padding: "0.375rem 0.75rem",
-                    "border-radius": "9999px",
-                    "font-size": "0.8125rem",
-                    "font-weight": "500",
-                    border: `1px solid ${status().expired ? "var(--accent-error)" : "var(--accent-success)"}`,
-                    background: status().expired
-                      ? "color-mix(in srgb, var(--accent-error) 12%, transparent)"
-                      : "color-mix(in srgb, var(--accent-success) 12%, transparent)",
-                    color: status().expired ? "var(--accent-error)" : "var(--accent-success)",
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium self-start"
+                  classList={{
+                    "border border-[var(--accent-error)] bg-[color-mix(in_srgb,var(--accent-error)_12%,transparent)] text-[var(--accent-error)]":
+                      status().expired,
+                    "border border-[var(--accent-success)] bg-[color-mix(in_srgb,var(--accent-success)_12%,transparent)] text-[var(--accent-success)]":
+                      !status().expired,
                   }}
                 >
-                  <span
-                    style={{
-                      width: "6px",
-                      height: "6px",
-                      "border-radius": "50%",
-                      background: "currentColor",
-                      display: "inline-block",
-                      "flex-shrink": "0",
-                    }}
-                  />
+                  <span class="w-1.5 h-1.5 rounded-full bg-current shrink-0" />
                   {status().label}
                 </div>
               )}
             </Show>
 
             <Show when={claimsSummary().length > 0}>
-              <div
-                style={{
-                  background: "var(--bg-secondary)",
-                  border: "1px solid var(--border)",
-                  "border-radius": "0.5rem",
-                  overflow: "hidden",
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    "align-items": "center",
-                    "justify-content": "space-between",
-                    padding: "0.625rem 1rem",
-                    "border-bottom": "1px solid var(--border)",
-                  }}
-                >
-                  <span class="tool-label">Claims summary</span>
+              <Card class="overflow-hidden p-0">
+                <div class="flex items-center justify-between px-4 py-2.5 border-b border-[var(--border)]">
+                  <Label>Claims summary</Label>
                 </div>
-                <div
-                  style={{
-                    display: "grid",
-                    "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
-                    gap: "0.75rem",
-                    padding: "1rem",
-                  }}
-                >
+                <div class="p-4 grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
                   {claimsSummary().map((item) => (
-                    <div
-                      style={{
-                        display: "flex",
-                        "flex-direction": "column",
-                        gap: "0.25rem",
-                        padding: "0.75rem",
-                        background: "var(--bg-primary)",
-                        border: "1px solid var(--border)",
-                        "border-radius": "0.375rem",
-                      }}
-                    >
-                      <span
-                        style={{
-                          "font-size": "0.6875rem",
-                          "font-weight": "700",
-                          "letter-spacing": "0.06em",
-                          "text-transform": "uppercase",
-                          color: "var(--text-muted)",
-                        }}
-                      >
+                    <div class="flex flex-col gap-1 p-3 bg-[var(--bg-primary)] border border-[var(--border)] rounded">
+                      <span class="text-[0.6875rem] font-bold tracking-wider uppercase text-[var(--text-muted)]">
                         {item.section} · {item.label}
                       </span>
-                      <code
-                        style={{
-                          color: "var(--text-primary)",
-                          "font-size": "0.8125rem",
-                          "font-family": "var(--font-mono)",
-                          "word-break": "break-word",
-                        }}
-                      >
+                      <code class="text-[var(--text-primary)] text-xs font-mono break-words">
                         {item.displayValue}
                       </code>
                       <Show when={item.displayValue !== item.rawValue}>
-                        <span
-                          style={{
-                            color: "var(--text-secondary)",
-                            "font-size": "0.75rem",
-                            "font-family": "var(--font-mono)",
-                            "word-break": "break-word",
-                          }}
-                        >
+                        <span class="text-[var(--text-secondary)] text-xs font-mono break-words">
                           raw: {item.rawValue}
                         </span>
                       </Show>
                     </div>
                   ))}
                 </div>
-              </div>
+              </Card>
             </Show>
 
             {/* Header panel */}

--- a/src/tools/regex-tester/RegexTester.tsx
+++ b/src/tools/regex-tester/RegexTester.tsx
@@ -3,6 +3,10 @@ import { createMemo, createSignal, For, Show } from "solid-js";
 import CopyButton from "@/components/CopyButton";
 import ToolActionButton from "@/components/ToolActionButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Card from "@/components/primitives/solid/Card";
+import Input from "@/components/primitives/solid/Input";
+import Label from "@/components/primitives/solid/Label";
+import Textarea from "@/components/primitives/solid/Textarea";
 import {
   buildRegexReplaceResult,
   buildRegexResult,
@@ -71,9 +75,9 @@ export default function RegexTester() {
   const hasCaptures = createMemo(() => result().matches.some((match) => match.groups.length > 0));
 
   return (
-    <div class="tool-container">
-      <div style={{ display: "flex", "flex-direction": "column", gap: "0.5rem" }}>
-        <div style={{ display: "flex", gap: "0.5rem", "flex-wrap": "wrap" }}>
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full">
+      <div class="flex flex-col gap-2">
+        <div class="flex gap-2 flex-wrap">
           <ToolActionButton
             active={mode() === "match"}
             variant={mode() === "match" ? "primary" : "ghost"}
@@ -90,29 +94,15 @@ export default function RegexTester() {
           </ToolActionButton>
         </div>
 
-        <label class="tool-label">Pattern</label>
+        <Label>Pattern</Label>
         <div
-          style={{
-            display: "flex",
-            "align-items": "center",
-            background: "var(--bg-secondary)",
-            border: `1px solid ${result().error ? "var(--accent-error)" : "var(--border)"}`,
-            "border-radius": "0.5rem",
-            overflow: "hidden",
-            transition: "border-color 0.15s",
+          class="flex items-center bg-[var(--bg-secondary)] rounded-lg overflow-hidden transition-[border-color] duration-150"
+          classList={{
+            "border border-[var(--accent-error)]": !!result().error,
+            "border border-[var(--border)]": !result().error,
           }}
         >
-          <span
-            style={{
-              padding: "0 0.5rem 0 0.875rem",
-              color: "var(--text-muted)",
-              "font-family": "var(--font-mono)",
-              "font-size": "1.125rem",
-              "user-select": "none",
-            }}
-          >
-            /
-          </span>
+          <span class="pl-3.5 pr-2 text-[var(--text-muted)] font-mono text-lg select-none">/</span>
 
           <input
             type="text"
@@ -120,53 +110,21 @@ export default function RegexTester() {
             onInput={(e) => setPattern(e.currentTarget.value)}
             placeholder="pattern"
             spellcheck={false}
-            style={{
-              flex: "1",
-              padding: "0.625rem 0",
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "font-size": "0.9375rem",
-            }}
+            class="flex-1 py-2.5 bg-transparent border-none outline-none text-[var(--text-primary)] font-mono text-[0.9375rem]"
           />
 
-          <span
-            style={{
-              color: "var(--text-muted)",
-              "font-family": "var(--font-mono)",
-              "font-size": "1.125rem",
-              "user-select": "none",
-            }}
-          >
-            /
-          </span>
+          <span class="text-[var(--text-muted)] font-mono text-lg select-none">/</span>
 
-          <div
-            style={{
-              display: "flex",
-              "align-items": "center",
-              gap: "0.125rem",
-              padding: "0 0.75rem",
-            }}
-          >
+          <div class="flex items-center gap-0.5 px-3">
             <For each={ALL_FLAGS}>
               {(flag) => (
                 <button
                   title={flag.title}
                   onClick={() => toggleFlag(flag.key)}
-                  style={{
-                    padding: "0.125rem 0.375rem",
-                    "border-radius": "0.25rem",
-                    border: "none",
-                    background: flags().has(flag.key) ? "var(--accent-primary)" : "transparent",
-                    color: flags().has(flag.key) ? "var(--bg-primary)" : "var(--text-muted)",
-                    "font-family": "var(--font-mono)",
-                    "font-size": "0.875rem",
-                    "font-weight": "700",
-                    cursor: "pointer",
-                    transition: "background 0.1s, color 0.1s",
+                  class="px-1.5 py-0.5 rounded border-none font-mono text-sm font-bold cursor-pointer transition-[background,color] duration-100"
+                  classList={{
+                    "bg-[var(--accent-primary)] text-[var(--bg-primary)]": flags().has(flag.key),
+                    "bg-transparent text-[var(--text-muted)]": !flags().has(flag.key),
                   }}
                 >
                   {flag.label}
@@ -179,65 +137,49 @@ export default function RegexTester() {
 
       <Show when={result().error}>
         {(msg) => (
-          <ToolStatusMessage
-            tone="error"
-            style={{
-              "font-family": "var(--font-mono)",
-            }}
-          >
+          <ToolStatusMessage tone="error" class="font-mono">
             {msg()}
           </ToolStatusMessage>
         )}
       </Show>
 
-      <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-        <label class="tool-label">Test string</label>
-        <textarea
+      <div class="flex flex-col gap-1.5">
+        <Label>Test string</Label>
+        <Textarea
           value={input()}
-          onInput={(e) => setInput(e.currentTarget.value)}
+          onInput={setInput}
           placeholder="Enter text to test against the pattern…"
           rows={6}
           spellcheck={false}
-          class="tool-textarea"
         />
       </div>
 
       <Show when={mode() === "replace"}>
-        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-          <label class="tool-label">Replacement</label>
-          <input
-            type="text"
-            value={replacement()}
-            onInput={(e) => setReplacement(e.currentTarget.value)}
-            placeholder="Replacement text"
-            spellcheck={false}
-            class="tool-input"
-          />
+        <div class="flex flex-col gap-1.5">
+          <Label>Replacement</Label>
+          <Input value={replacement()} onInput={setReplacement} placeholder="Replacement text" />
         </div>
       </Show>
 
       <Show when={pattern() && !result().error}>
-        <div style={{ display: "flex", gap: "0.75rem", "flex-wrap": "wrap" }}>
-          <ToolStatusMessage
-            tone={matchCount() > 0 ? "success" : "muted"}
-            style={{ padding: "0.625rem 0.875rem" }}
-          >
+        <div class="flex gap-3 flex-wrap">
+          <ToolStatusMessage tone={matchCount() > 0 ? "success" : "muted"}>
             {matchCount() === 0
               ? "No matches"
               : `${matchCount()} ${matchCount() === 1 ? "match" : "matches"}`}
           </ToolStatusMessage>
-          <ToolStatusMessage tone="muted" style={{ padding: "0.625rem 0.875rem" }}>
+          <ToolStatusMessage tone="muted">
             {result().summary.captureGroupCount} capture{" "}
             {result().summary.captureGroupCount === 1 ? "group" : "groups"}
           </ToolStatusMessage>
           <Show when={result().summary.emptyMatchCount > 0}>
-            <ToolStatusMessage tone="warning" style={{ padding: "0.625rem 0.875rem" }}>
+            <ToolStatusMessage tone="warning">
               {result().summary.emptyMatchCount} empty
               {result().summary.emptyMatchCount === 1 ? " match" : " matches"}
             </ToolStatusMessage>
           </Show>
           <Show when={result().summary.firstMatchIndex !== null}>
-            <ToolStatusMessage tone="muted" style={{ padding: "0.625rem 0.875rem" }}>
+            <ToolStatusMessage tone="muted">
               First match at index {result().summary.firstMatchIndex}
             </ToolStatusMessage>
           </Show>
@@ -245,35 +187,18 @@ export default function RegexTester() {
       </Show>
 
       <Show when={input().trim()}>
-        <div
-          style={{
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "0.5rem",
-            overflow: "hidden",
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              "align-items": "center",
-              "justify-content": "space-between",
-              padding: "0.5rem 1rem",
-              "border-bottom": "1px solid var(--border)",
-            }}
-          >
-            <span class="tool-label">{mode() === "replace" ? "Match preview" : "Matches"}</span>
+        <Card class="overflow-hidden p-0">
+          <div class="flex items-center justify-between px-4 py-2 border-b border-[var(--border)]">
+            <Label>{mode() === "replace" ? "Match preview" : "Matches"}</Label>
             <Show
               when={pattern() && !result().error}
-              fallback={
-                <span style={{ "font-size": "0.8125rem", color: "var(--text-muted)" }}>—</span>
-              }
+              fallback={<span class="text-xs text-[var(--text-muted)]">—</span>}
             >
               <span
-                style={{
-                  "font-size": "0.8125rem",
-                  "font-weight": "600",
-                  color: matchCount() > 0 ? "var(--accent-success)" : "var(--text-muted)",
+                class="text-xs font-semibold"
+                classList={{
+                  "text-[var(--accent-success)]": matchCount() > 0,
+                  "text-[var(--text-muted)]": matchCount() === 0,
                 }}
               >
                 {mode() === "replace"
@@ -288,20 +213,10 @@ export default function RegexTester() {
           </div>
 
           <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "overflow-x": "auto",
-              "font-size": "0.875rem",
-              "line-height": "1.8",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "white-space": "pre-wrap",
-              "word-break": "break-all",
-            }}
+            class="m-0 p-4 overflow-x-auto text-sm leading-relaxed text-[var(--text-primary)] font-mono whitespace-pre-wrap break-all"
             innerHTML={result().highlighted}
           />
-        </div>
+        </Card>
       </Show>
 
       <Show
@@ -309,105 +224,38 @@ export default function RegexTester() {
           mode() === "replace" && input().trim() && !result().error && !("error" in replaceResult())
         }
       >
-        <div
-          style={{
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "0.5rem",
-            overflow: "hidden",
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              "align-items": "center",
-              "justify-content": "space-between",
-              padding: "0.5rem 1rem",
-              "border-bottom": "1px solid var(--border)",
-            }}
-          >
-            <span class="tool-label">Replaced output</span>
+        <Card class="overflow-hidden p-0">
+          <div class="flex items-center justify-between px-4 py-2 border-b border-[var(--border)]">
+            <Label>Replaced output</Label>
             <CopyButton text={replaceOutput()} />
           </div>
 
-          <pre
-            style={{
-              margin: "0",
-              padding: "1rem",
-              "overflow-x": "auto",
-              "font-size": "0.875rem",
-              "line-height": "1.8",
-              color: "var(--text-primary)",
-              "font-family": "var(--font-mono)",
-              "white-space": "pre-wrap",
-              "word-break": "break-all",
-            }}
-          >
+          <pre class="m-0 p-4 overflow-x-auto text-sm leading-relaxed text-[var(--text-primary)] font-mono whitespace-pre-wrap break-all">
             {replaceOutput()}
           </pre>
-        </div>
+        </Card>
       </Show>
 
       <Show when={hasCaptures() && matchCount() > 0}>
-        <div
-          style={{
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "0.5rem",
-            overflow: "hidden",
-          }}
-        >
-          <div style={{ padding: "0.5rem 1rem", "border-bottom": "1px solid var(--border)" }}>
-            <span class="tool-label">Capture groups</span>
+        <Card class="overflow-hidden p-0">
+          <div class="px-4 py-2 border-b border-[var(--border)]">
+            <Label>Capture groups</Label>
           </div>
 
-          <div style={{ overflow: "auto" }}>
-            <table
-              style={{
-                width: "100%",
-                "border-collapse": "collapse",
-                "font-size": "0.8125rem",
-                "font-family": "var(--font-mono)",
-              }}
-            >
+          <div class="overflow-auto">
+            <table class="w-full border-collapse font-mono text-sm">
               <thead>
                 <tr>
-                  <th
-                    style={{
-                      padding: "0.5rem 1rem",
-                      "text-align": "left",
-                      color: "var(--text-muted)",
-                      "font-weight": "600",
-                      "border-bottom": "1px solid var(--border)",
-                      "white-space": "nowrap",
-                    }}
-                  >
+                  <th class="px-4 py-2 text-left text-[var(--text-muted)] font-semibold border-b border-[var(--border)] whitespace-nowrap">
                     Match #
                   </th>
-                  <th
-                    style={{
-                      padding: "0.5rem 1rem",
-                      "text-align": "left",
-                      color: "var(--text-muted)",
-                      "font-weight": "600",
-                      "border-bottom": "1px solid var(--border)",
-                    }}
-                  >
+                  <th class="px-4 py-2 text-left text-[var(--text-muted)] font-semibold border-b border-[var(--border)]">
                     Full match
                   </th>
                   <Show when={namedGroupNames().length > 0}>
                     <For each={namedGroupNames()}>
                       {(name) => (
-                        <th
-                          style={{
-                            padding: "0.5rem 1rem",
-                            "text-align": "left",
-                            color: "var(--accent-primary)",
-                            "font-weight": "600",
-                            "border-bottom": "1px solid var(--border)",
-                            "white-space": "nowrap",
-                          }}
-                        >
+                        <th class="px-4 py-2 text-left text-[var(--accent-primary)] font-semibold border-b border-[var(--border)] whitespace-nowrap">
                           {name}
                         </th>
                       )}
@@ -418,15 +266,7 @@ export default function RegexTester() {
                       match.groups.some((group) => group.name === null)
                     )}
                   >
-                    <th
-                      style={{
-                        padding: "0.5rem 1rem",
-                        "text-align": "left",
-                        color: "var(--text-muted)",
-                        "font-weight": "600",
-                        "border-bottom": "1px solid var(--border)",
-                      }}
-                    >
+                    <th class="px-4 py-2 text-left text-[var(--text-muted)] font-semibold border-b border-[var(--border)]">
                       Groups
                     </th>
                   </Show>
@@ -436,31 +276,12 @@ export default function RegexTester() {
                 <For each={result().matches}>
                   {(match: MatchResult, index) => (
                     <tr>
-                      <td
-                        style={{
-                          padding: "0.375rem 1rem",
-                          color: "var(--text-muted)",
-                          "border-bottom": "1px solid var(--border)",
-                          "white-space": "nowrap",
-                        }}
-                      >
+                      <td class="px-4 py-1.5 text-[var(--text-muted)] border-b border-[var(--border)] whitespace-nowrap">
                         {index() + 1}
                       </td>
-                      <td
-                        style={{
-                          padding: "0.375rem 1rem",
-                          color: "var(--text-primary)",
-                          "border-bottom": "1px solid var(--border)",
-                          "max-width": "200px",
-                          overflow: "hidden",
-                          "text-overflow": "ellipsis",
-                          "white-space": "nowrap",
-                        }}
-                      >
-                        <div style={{ display: "flex", "align-items": "center", gap: "0.5rem" }}>
-                          <span
-                            style={{ flex: "1", overflow: "hidden", "text-overflow": "ellipsis" }}
-                          >
+                      <td class="px-4 py-1.5 text-[var(--text-primary)] border-b border-[var(--border)] max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap">
+                        <div class="flex items-center gap-2">
+                          <span class="flex-1 overflow-hidden text-ellipsis">
                             {match.fullMatch}
                           </span>
                           <CopyButton text={match.fullMatch} />
@@ -472,10 +293,10 @@ export default function RegexTester() {
                             const group = match.groups.find((candidate) => candidate.name === name);
                             return (
                               <td
-                                style={{
-                                  padding: "0.375rem 1rem",
-                                  color: group ? "var(--accent-success)" : "var(--text-muted)",
-                                  "border-bottom": "1px solid var(--border)",
+                                class="px-4 py-1.5 border-b border-[var(--border)]"
+                                classList={{
+                                  "text-[var(--accent-success)]": !!group,
+                                  "text-[var(--text-muted)]": !group,
                                 }}
                               >
                                 {group ? group.value : "—"}
@@ -485,13 +306,7 @@ export default function RegexTester() {
                         </For>
                       </Show>
                       <Show when={match.groups.some((group) => group.name === null)}>
-                        <td
-                          style={{
-                            padding: "0.375rem 1rem",
-                            color: "var(--text-primary)",
-                            "border-bottom": "1px solid var(--border)",
-                          }}
-                        >
+                        <td class="px-4 py-1.5 text-[var(--text-primary)] border-b border-[var(--border)]">
                           {match.groups
                             .filter((group) => group.name === null)
                             .map((group) => group.value)
@@ -504,7 +319,7 @@ export default function RegexTester() {
               </tbody>
             </table>
           </div>
-        </div>
+        </Card>
       </Show>
 
       <Show when={!pattern() && !input().trim()}>

--- a/src/tools/timestamp/TimestampTool.tsx
+++ b/src/tools/timestamp/TimestampTool.tsx
@@ -3,6 +3,10 @@ import { createMemo, createSignal, For, Show } from "solid-js";
 import CopyButton from "@/components/CopyButton";
 import ToolActionButton from "@/components/ToolActionButton";
 import ToolStatusMessage from "@/components/ToolStatusMessage";
+import Card from "@/components/primitives/solid/Card";
+import Input from "@/components/primitives/solid/Input";
+import Label from "@/components/primitives/solid/Label";
+import Select from "@/components/primitives/solid/Select";
 import {
   DEFAULT_ZONES,
   formatInZone,
@@ -71,52 +75,31 @@ export default function TimestampTool() {
     setZones((prev) => prev.map((z, i) => (i === index ? { ...z, tz } : z)));
   }
 
-  const inputStyle = {
-    padding: "0.625rem 0.875rem",
-    "border-radius": "0.375rem",
-    border: "1px solid var(--border)",
-    background: "var(--bg-secondary)",
-    color: "var(--text-primary)",
-    "font-family": "var(--font-mono)",
-    "font-size": "0.875rem",
-    outline: "none",
-    "box-sizing": "border-box" as const,
-  };
-
   return (
-    <div class="tool-container" style={{ "--tool-max-width": "760px", "--tool-gap": "1.5rem" }}>
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[760px]">
       {/* ------------------------------------------------------------------ */}
       {/* Input row                                                           */}
       {/* ------------------------------------------------------------------ */}
-      <div
-        style={{
-          display: "grid",
-          "grid-template-columns": "1fr auto 1fr",
-          gap: "1rem",
-          "align-items": "end",
-        }}
-      >
+      <div class="grid grid-cols-[1fr_auto_1fr] gap-4 items-end">
         {/* Epoch input */}
-        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-          <label class="tool-label">Unix timestamp</label>
-          <input
+        <div class="flex flex-col gap-1.5">
+          <Label>Unix timestamp</Label>
+          <Input
             type="text"
-            inputmode="numeric"
             value={epochInput()}
-            onInput={(e) => handleEpochInput(e.currentTarget.value)}
+            onInput={handleEpochInput}
             placeholder="e.g. 1700000000"
-            style={{ ...inputStyle, width: "100%" }}
           />
           <Show when={parsed()}>
             {(p) => (
-              <span style={{ "font-size": "0.75rem", color: "var(--text-muted)" }}>
+              <span class="text-xs text-[var(--text-muted)]">
                 Detected: {p().unit === "s" ? "seconds" : "milliseconds"}
               </span>
             )}
           </Show>
         </div>
 
-        <div style={{ display: "flex", gap: "0.5rem", "align-items": "center" }}>
+        <div class="flex gap-2 items-center">
           <ToolActionButton onClick={useNow} variant="primary">
             Use now
           </ToolActionButton>
@@ -126,14 +109,9 @@ export default function TimestampTool() {
         </div>
 
         {/* Datetime-local input */}
-        <div style={{ display: "flex", "flex-direction": "column", gap: "0.375rem" }}>
-          <label class="tool-label">Date & time (local)</label>
-          <input
-            type="datetime-local"
-            value={datetimeInput()}
-            onInput={(e) => handleDatetimeInput(e.currentTarget.value)}
-            style={{ ...inputStyle, width: "100%" }}
-          />
+        <div class="flex flex-col gap-1.5">
+          <Label>Date & time (local)</Label>
+          <Input type="datetime-local" value={datetimeInput()} onInput={handleDatetimeInput} />
         </div>
       </div>
 
@@ -142,180 +120,69 @@ export default function TimestampTool() {
       {/* ------------------------------------------------------------------ */}
       <Show when={date()}>
         {(d) => (
-          <div
-            style={{
-              display: "flex",
-              gap: "0.75rem",
-              "flex-wrap": "wrap",
-            }}
-          >
+          <div class="flex gap-3 flex-wrap">
             {/* Seconds */}
-            <div
-              style={{
-                flex: "1",
-                "min-width": "160px",
-                background: "var(--bg-secondary)",
-                border: "1px solid var(--border)",
-                "border-radius": "0.5rem",
-                padding: "0.875rem 1rem",
-              }}
-            >
-              <div class="tool-label">Epoch (seconds)</div>
-              <div
-                style={{
-                  display: "flex",
-                  "align-items": "center",
-                  gap: "0.5rem",
-                  "margin-top": "0.375rem",
-                }}
-              >
-                <code
-                  style={{
-                    "font-size": "0.9375rem",
-                    color: "var(--accent-primary)",
-                    "font-family": "var(--font-mono)",
-                    flex: "1",
-                    "word-break": "break-all",
-                  }}
-                >
+            <Card class="flex-1 min-w-[160px]">
+              <Label>Epoch (seconds)</Label>
+              <div class="flex items-center gap-2 mt-1.5">
+                <code class="text-[0.9375rem] text-[var(--accent-primary)] font-mono flex-1 break-all">
                   {String(Math.floor(d().getTime() / 1000))}
                 </code>
                 <CopyButton text={String(Math.floor(d().getTime() / 1000))} />
               </div>
-            </div>
+            </Card>
 
             {/* Milliseconds */}
-            <div
-              style={{
-                flex: "1",
-                "min-width": "160px",
-                background: "var(--bg-secondary)",
-                border: "1px solid var(--border)",
-                "border-radius": "0.5rem",
-                padding: "0.875rem 1rem",
-              }}
-            >
-              <div class="tool-label">Epoch (milliseconds)</div>
-              <div
-                style={{
-                  display: "flex",
-                  "align-items": "center",
-                  gap: "0.5rem",
-                  "margin-top": "0.375rem",
-                }}
-              >
-                <code
-                  style={{
-                    "font-size": "0.9375rem",
-                    color: "var(--accent-primary)",
-                    "font-family": "var(--font-mono)",
-                    flex: "1",
-                    "word-break": "break-all",
-                  }}
-                >
+            <Card class="flex-1 min-w-[160px]">
+              <Label>Epoch (milliseconds)</Label>
+              <div class="flex items-center gap-2 mt-1.5">
+                <code class="text-[0.9375rem] text-[var(--accent-primary)] font-mono flex-1 break-all">
                   {String(d().getTime())}
                 </code>
                 <CopyButton text={String(d().getTime())} />
               </div>
-            </div>
+            </Card>
 
             {/* ISO 8601 */}
-            <div
-              style={{
-                flex: "2",
-                "min-width": "220px",
-                background: "var(--bg-secondary)",
-                border: "1px solid var(--border)",
-                "border-radius": "0.5rem",
-                padding: "0.875rem 1rem",
-              }}
-            >
-              <div class="tool-label">ISO 8601</div>
-              <div
-                style={{
-                  display: "flex",
-                  "align-items": "center",
-                  gap: "0.5rem",
-                  "margin-top": "0.375rem",
-                }}
-              >
-                <code
-                  style={{
-                    "font-size": "0.875rem",
-                    color: "var(--accent-success)",
-                    "font-family": "var(--font-mono)",
-                    flex: "1",
-                    "word-break": "break-all",
-                  }}
-                >
+            <Card class="flex-[2] min-w-[220px]">
+              <Label>ISO 8601</Label>
+              <div class="flex items-center gap-2 mt-1.5">
+                <code class="text-sm text-[var(--accent-success)] font-mono flex-1 break-all">
                   {d().toISOString()}
                 </code>
                 <CopyButton text={d().toISOString()} />
               </div>
-            </div>
+            </Card>
           </div>
         )}
       </Show>
 
+      {/* ------------------------------------------------------------------ */}
+      {/* Derived formats                                                     */}
+      {/* ------------------------------------------------------------------ */}
       <Show when={date()}>
         {(d) => (
-          <div
-            style={{
-              background: "var(--bg-secondary)",
-              border: "1px solid var(--border)",
-              "border-radius": "0.5rem",
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                padding: "0.625rem 1rem",
-                "border-bottom": "1px solid var(--border)",
-              }}
-            >
-              <span class="tool-label">Derived formats</span>
+          <Card class="overflow-hidden p-0">
+            <div class="px-4 py-2.5 border-b border-[var(--border)]">
+              <Label>Derived formats</Label>
             </div>
 
-            <div
-              style={{
-                padding: "0.75rem 1rem",
-                display: "grid",
-                "grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
-                gap: "0.75rem",
-              }}
-            >
+            <div class="p-3 grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
               <For each={getDerivedTimestampFormats(d())}>
                 {(item) => (
-                  <div
-                    style={{
-                      display: "flex",
-                      "flex-direction": "column",
-                      gap: "0.375rem",
-                      padding: "0.75rem",
-                      background: "var(--bg-primary)",
-                      border: "1px solid var(--border)",
-                      "border-radius": "0.375rem",
-                    }}
-                  >
-                    <span class="tool-label">{item.label}</span>
-                    <code
-                      style={{
-                        "font-size": "0.8125rem",
-                        color: "var(--text-primary)",
-                        "font-family": "var(--font-mono)",
-                        "word-break": "break-all",
-                      }}
-                    >
+                  <div class="flex flex-col gap-1.5 p-3 bg-[var(--bg-primary)] border border-[var(--border)] rounded">
+                    <Label>{item.label}</Label>
+                    <code class="text-[0.8125rem] text-[var(--text-primary)] font-mono break-all">
                       {item.value}
                     </code>
-                    <div style={{ display: "flex", "justify-content": "flex-end" }}>
+                    <div class="flex justify-end">
                       <CopyButton text={item.value} />
                     </div>
                   </div>
                 )}
               </For>
             </div>
-          </div>
+          </Card>
         )}
       </Show>
 
@@ -324,67 +191,22 @@ export default function TimestampTool() {
       {/* ------------------------------------------------------------------ */}
       <Show when={date()}>
         {(d) => (
-          <div
-            style={{
-              background: "var(--bg-secondary)",
-              border: "1px solid var(--border)",
-              "border-radius": "0.5rem",
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                padding: "0.625rem 1rem",
-                "border-bottom": "1px solid var(--border)",
-              }}
-            >
-              <span class="tool-label">Timezone conversions</span>
+          <Card class="overflow-hidden p-0">
+            <div class="px-4 py-2.5 border-b border-[var(--border)]">
+              <Label>Timezone conversions</Label>
             </div>
 
-            <div
-              style={{
-                padding: "0.75rem 1rem",
-                display: "flex",
-                "flex-direction": "column",
-                gap: "0.75rem",
-              }}
-            >
+            <div class="p-3 flex flex-col gap-3">
               <For each={zones()}>
                 {(zone, i) => (
-                  <div
-                    style={{
-                      display: "grid",
-                      "grid-template-columns": "180px 1fr auto",
-                      gap: "0.75rem",
-                      "align-items": "center",
-                    }}
-                  >
-                    <select
+                  <div class="grid grid-cols-[180px_1fr_auto] gap-3 items-center">
+                    <Select
                       value={zone.tz}
-                      onChange={(e) => changeZone(i(), e.currentTarget.value)}
-                      style={{
-                        padding: "0.25rem 0.5rem",
-                        "border-radius": "0.25rem",
-                        border: "1px solid var(--border)",
-                        background: "var(--bg-tertiary)",
-                        color: "var(--text-secondary)",
-                        "font-size": "0.75rem",
-                        cursor: "pointer",
-                        outline: "none",
-                      }}
-                    >
-                      <For each={PRESET_ZONES}>
-                        {(preset) => <option value={preset.tz}>{preset.label}</option>}
-                      </For>
-                    </select>
+                      onChange={(tz) => changeZone(i(), tz)}
+                      options={PRESET_ZONES.map((z) => ({ value: z.tz, label: z.label }))}
+                    />
 
-                    <code
-                      style={{
-                        "font-size": "0.875rem",
-                        color: "var(--text-primary)",
-                        "font-family": "var(--font-mono)",
-                      }}
-                    >
+                    <code class="text-sm text-[var(--text-primary)] font-mono">
                       {formatInZone(d(), zone.tz)}
                     </code>
 
@@ -393,7 +215,7 @@ export default function TimestampTool() {
                 )}
               </For>
             </div>
-          </div>
+          </Card>
         )}
       </Show>
 


### PR DESCRIPTION
## Summary

Migrate the five most complex tools (timestamp, regex-tester, jwt-decoder, base64, hash-generator) from inline CSS to primitives + Tailwind. Also add `readonly` prop to Textarea primitive. Net -578 lines.

## Changes

- Add `readonly` prop to Textarea primitive (needed by Base64Tool, HashGenerator file mode)
- `TimestampTool`: removed `inputStyle` object; migrated epoch cards, derived formats, timezone select to primitives
- `RegexTester`: migrated pattern input with /.../ delimiters, match preview, capture groups table to Tailwind; removed inline style from all ToolStatusMessages
- `JwtDecoder`: replaced Panel sub-component with Card primitives; migrated expiry badge, claims summary, error alert
- `Base64Tool`: migrated mode/variant/workflow toggles, drag-drop textarea, output panel
- `HashGenerator`: migrated workflow toggle, drag-drop textarea, open file label, hash result cards
- Net: 202 insertions, 780 deletions

## Testing

**Automated**
- [x] `bun run verify` passed (type-check ✓, lint ✓, format ✓, build ✓, 172 tests ✓)

**Manual**
- [x] Visit each tool page — verify full functionality including file upload, drag-drop, conditional error borders, and interactive controls