### PR TITLE
refactor: add id prop to Input, Textarea, Select for label binding

### DIFF
--- a/src/components/primitives/solid/Input.tsx
+++ b/src/components/primitives/solid/Input.tsx
@@ -8,13 +8,15 @@ export interface InputProps {
   placeholder?: string;
   type?: string;
   class?: string;
+  id?: string;
 }
 
 export default function Input(props: InputProps) {
   return (
     <div class={cn("flex flex-col gap-1.5", props.class)}>
-      {props.label ? <Label>{props.label}</Label> : null}
+      {props.label ? <Label for={props.id}>{props.label}</Label> : null}
       <input
+        id={props.id}
         type={props.type ?? "text"}
         value={props.value ?? ""}
         onInput={(e) => props.onInput?.((e.target as HTMLInputElement).value)}

--- a/src/components/primitives/solid/Select.tsx
+++ b/src/components/primitives/solid/Select.tsx
@@ -12,13 +12,15 @@ export interface SelectProps {
   onChange?: (value: string) => void;
   options?: SelectOption[];
   class?: string;
+  id?: string;
 }
 
 export default function Select(props: SelectProps) {
   return (
     <div class={cn("flex flex-col gap-1.5", props.class)}>
-      {props.label ? <Label>{props.label}</Label> : null}
+      {props.label ? <Label for={props.id}>{props.label}</Label> : null}
       <select
+        id={props.id}
         value={props.value ?? ""}
         onChange={(e) => props.onChange?.((e.target as HTMLSelectElement).value)}
         class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-2.5 text-sm text-[var(--text-primary)] outline-none font-mono focus:border-[var(--accent-primary)]"

--- a/src/components/primitives/solid/Textarea.tsx
+++ b/src/components/primitives/solid/Textarea.tsx
@@ -12,13 +12,15 @@ export interface TextareaProps {
   autofocus?: boolean;
   spellcheck?: boolean;
   readonly?: boolean;
+  id?: string;
 }
 
 export default function Textarea(props: TextareaProps) {
   return (
     <div class={cn("flex flex-col gap-1.5", props.class)}>
-      {props.label ? <Label>{props.label}</Label> : null}
+      {props.label ? <Label for={props.id}>{props.label}</Label> : null}
       <textarea
+        id={props.id}
         value={props.value ?? ""}
         onInput={(e) => props.onInput?.((e.target as HTMLTextAreaElement).value)}
         placeholder={props.placeholder}


### PR DESCRIPTION
## Summary
Add optional `id` prop to Input, Textarea, and Select primitives so the visual Label is semantically associated with its input element via `for`/id binding.

## Changes
- Add `id` prop to Input, Textarea, and Select interfaces
- Pass `id` to the underlying `<input>`, `<textarea>`, or `<select>` element
- Pass `id` to the Label's `for` attribute for programmatic association

## Testing
**Automated**
- [x] `bun run verify` passed (31 test files, 172 tests)

## Notes
Backward compatible — `id` is optional, existing callers are unaffected.