### PR TITLE
refactor: replace onMount waterfall with createResource and skeleton

### DIFF
--- a/src/components/ToolHost.tsx
+++ b/src/components/ToolHost.tsx
@@ -1,4 +1,4 @@
-import { createSignal, ErrorBoundary, onMount, Show } from "solid-js";
+import { createResource, ErrorBoundary, Show } from "solid-js";
 import type { Component } from "solid-js";
 import { Dynamic, isServer } from "solid-js/web";
 
@@ -11,54 +11,55 @@ interface ToolHostProps {
 
 const toolModules = import.meta.glob<{ default: Component }>("../tools/*/*.tsx");
 
+async function loadToolModule(componentPath: string): Promise<Component> {
+  const modulePath = `../${componentPath.slice(5)}`;
+  const loadTool = toolModules[modulePath];
+  if (!loadTool) {
+    throw new Error(`Missing tool component loader for ${componentPath}`);
+  }
+  const module = await loadTool();
+  return module.default;
+}
+
+function ToolSkeleton() {
+  return (
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[860px] animate-pulse">
+      <div class="flex gap-3 items-center">
+        <div class="h-8 w-32 bg-[var(--bg-tertiary)] rounded" />
+        <div class="h-8 w-24 bg-[var(--bg-tertiary)] rounded" />
+      </div>
+      <div class="h-40 w-full bg-[var(--bg-tertiary)] rounded-lg" />
+      <div class="h-8 w-48 bg-[var(--bg-tertiary)] rounded" />
+      <div class="h-32 w-full bg-[var(--bg-tertiary)] rounded-lg" />
+      <div class="flex gap-3 items-center">
+        <div class="h-8 w-20 bg-[var(--bg-tertiary)] rounded" />
+        <div class="h-8 w-20 bg-[var(--bg-tertiary)] rounded" />
+        <div class="h-8 w-28 bg-[var(--bg-tertiary)] rounded" />
+      </div>
+    </div>
+  );
+}
+
 export default function ToolHost(props: ToolHostProps) {
-  const [toolComponent, setToolComponent] = createSignal<Component | null>(null);
-  const [loadError, setLoadError] = createSignal<unknown>(null);
-
-  async function loadToolComponent() {
-    setLoadError(null);
-
-    try {
-      const modulePath = `../${props.componentPath.slice(5)}`;
-      const loadTool = toolModules[modulePath];
-
-      if (!loadTool) {
-        throw new Error(`Missing tool component loader for ${props.componentPath}`);
-      }
-
-      const module = await loadTool();
-      setToolComponent(() => module.default);
-    } catch (error) {
-      setToolComponent(null);
-      setLoadError(error);
-    }
-  }
-
-  onMount(async () => {
-    await loadToolComponent();
-  });
-
   if (isServer) {
-    return null;
+    return <ToolSkeleton />;
   }
+
+  const [toolComponent, { refetch }] = createResource(() => props.componentPath, loadToolModule);
 
   return (
-    <Show
-      when={toolComponent()}
-      fallback={
-        loadError() ? (
-          <ToolErrorFallback
-            toolName={props.toolName}
-            error={loadError()}
-            onRetry={() => void loadToolComponent()}
-          />
-        ) : null
-      }
-    >
+    <Show when={toolComponent()} fallback={<ToolSkeleton />}>
       {(Component) => (
         <ErrorBoundary
           fallback={(error, reset) => (
-            <ToolErrorFallback toolName={props.toolName} error={error} onRetry={reset} />
+            <ToolErrorFallback
+              toolName={props.toolName}
+              error={error}
+              onRetry={() => {
+                reset();
+                refetch();
+              }}
+            />
           )}
         >
           <Dynamic component={Component()} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,3 +124,24 @@ body {
 .font-code {
   font-family: var(--font-mono);
 }
+
+/* Skeleton loading animation */
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
Eliminate the double-waterfall loading delay on tool pages. Previously, ToolHost used `onMount` + manual `import()` which forced the browser to load ToolHost first, THEN load the tool component. Now the import starts immediately during component creation via `createResource`, and a loading skeleton is shown in the meantime.

## Changes
- Replace `onMount` + manual dynamic import with `createResource` that starts loading immediately at component creation time
- Add `ToolSkeleton` component showing animated pulse placeholder shapes matching tool layout
- Server-render the skeleton via `isServer` guard so the HTML contains visual content immediately
- Add `@keyframes pulse` animation with `prefers-reduced-motion` support to global.css

## Testing
**Automated**
- [x] `bun run verify` passed (31 test files, 172 tests)

**Manual**
- [ ] Navigate between tool pages — should feel snappier, skeleton appears instantly, tool replaces it when JS loads
- [ ] Hard-refresh on a tool page — skeleton visible while JS hydrates
- [ ] Verify no visual regression on any tool's interactive elements