### PR TITLE
fix: remove stale debounce from regex tester replacement input

### DIFF
--- a/src/tools/regex-tester/RegexTester.tsx
+++ b/src/tools/regex-tester/RegexTester.tsx
@@ -164,15 +164,7 @@ export default function RegexTester() {
       <Show when={mode() === "replace"}>
         <div class="flex flex-col gap-1.5">
           <Label>Replacement</Label>
-          <Input
-            value={replacement()}
-            onInput={(v) => {
-              setReplacement(v);
-              clearTimeout(debounceTimer);
-              debounceTimer = setTimeout(() => setDebouncedInput(v), 250);
-            }}
-            placeholder="Replacement text"
-          />
+          <Input value={replacement()} onInput={setReplacement} placeholder="Replacement text" />
         </div>
       </Show>
 


### PR DESCRIPTION
The replacement input's onInput handler was incorrectly updating debouncedInput to the replacement value and sharing the debounce timer with the test string input. Typing in the replacement field would cancel the pending test-string debounce and substitute the replacement text, causing match results to be computed against the wrong input.