### PR TITLE
chore: replace inline max-width styles with Tailwind classes

### DIFF
--- a/src/tools/case-converter/CaseConverter.tsx
+++ b/src/tools/case-converter/CaseConverter.tsx
@@ -27,7 +27,7 @@ export default function CaseConverter() {
   const hasInput = createMemo(() => input().trim().length > 0);
 
   return (
-    <div class="flex flex-col gap-5 p-6 mx-auto w-full" style="max-width: 900px">
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
       <Textarea
         label="Source text"
         value={input()}

--- a/src/tools/chmod-calculator/ChmodCalculatorTool.tsx
+++ b/src/tools/chmod-calculator/ChmodCalculatorTool.tsx
@@ -41,7 +41,7 @@ export default function ChmodCalculatorTool() {
   }
 
   return (
-    <div class="flex flex-col gap-5 p-6 mx-auto w-full" style="max-width: 900px">
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
       <Card class="overflow-auto">
         <table class="w-full border-collapse">
           <thead>

--- a/src/tools/cron/CronTool.tsx
+++ b/src/tools/cron/CronTool.tsx
@@ -38,7 +38,7 @@ export default function CronTool() {
   });
 
   return (
-    <div class="flex flex-col gap-5 p-6 mx-auto w-full" style="max-width: 900px">
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
       <div class="flex flex-col gap-1.5">
         <Label>Cron expression</Label>
         <input

--- a/src/tools/hmac-generator/HmacGeneratorTool.tsx
+++ b/src/tools/hmac-generator/HmacGeneratorTool.tsx
@@ -37,7 +37,7 @@ export default function HmacGeneratorTool() {
   }
 
   return (
-    <div class="flex flex-col gap-5 p-6 mx-auto w-full" style="max-width: 900px">
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
       <div class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(260px,1fr))]">
         <Textarea label="Message" value={message()} onInput={(v) => setMessage(v)} rows={6} />
         <Textarea label="Secret" value={secret()} onInput={(v) => setSecret(v)} rows={6} />

--- a/src/tools/text-statistics/TextStatisticsTool.tsx
+++ b/src/tools/text-statistics/TextStatisticsTool.tsx
@@ -18,7 +18,7 @@ export default function TextStatisticsTool() {
   const statistics = createMemo(() => analyzeText(input()));
 
   return (
-    <div class="flex flex-col gap-5 p-6 mx-auto w-full" style="max-width: 900px">
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
       <Textarea
         label="Text input"
         value={input()}

--- a/src/tools/token-generator/TokenGenerator.tsx
+++ b/src/tools/token-generator/TokenGenerator.tsx
@@ -59,7 +59,7 @@ export default function TokenGenerator() {
   }
 
   return (
-    <div class="flex flex-col gap-5 p-6 mx-auto w-full" style="max-width: 900px">
+    <div class="flex flex-col gap-5 p-6 mx-auto w-full max-w-[900px]">
       <div class="grid grid-cols-[2fr_1fr] gap-4">
         <Card class="flex flex-col gap-1.5">
           <div class="flex justify-between gap-3">


### PR DESCRIPTION
Converted all tool components using inline style='max-width: 900px' to Tailwind class max-w-[900px] for consistency with the rest of the codebase.