### PR TITLE
chore: configure dependabot weekly, limit 10, and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,11 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
       time: "09:00"
       timezone: "Asia/Kolkata"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
     commit-message:
@@ -20,14 +21,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        auto-merge: "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
       time: "09:30"
       timezone: "Asia/Kolkata"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
@@ -41,3 +44,4 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        auto-merge: "*"


### PR DESCRIPTION
## Changes

### Dependabot configuration updates for both Bun and GitHub Actions ecosystems:

- **Schedule**: `monthly` → `weekly` (Mondays) — security and bugfix patches arrive within a week instead of waiting up to 31 days
- **Open PR limit**: Bun `5` → `10`, Actions `2` → `5` — prevents the kind of backlog that caused dependency PRs to pile up
- **Auto-merge** (`auto-merge: "*"`) enabled on the `minor-and-patch` group for both ecosystems — minor/patch dependency bumps will merge automatically once CI passes, no manual review needed

### What stays the same

- Major version bumps still arrive as individual PRs for human review
- `@dependabot rebase` and other commands still work
- Labels, commit prefixes, and grouping strategy unchanged

### Prerequisite

For auto-merge to work, the repository needs auto-merge enabled. This requires a one-time toggle:

```
gh repo edit abijith-suresh/unwrapped --enable-auto-merge
```

I can run this after you approve, or you can do it from Settings → General → Allow auto-merge.

### Verification

`bun run verify` passes: type-check, lint, format, build, and all 172 tests — all green. Pre-commit and pre-push hooks also pass.